### PR TITLE
Adding http Request/Response injection

### DIFF
--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/VerifiedIdClientBuilder.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/VerifiedIdClientBuilder.kt
@@ -74,7 +74,7 @@ class VerifiedIdClientBuilder(private val context: Context) {
             logConsumer = vcSdkLogConsumer,
             userAgentInfo = getUserAgent(context),
             walletLibraryVersionInfo = getWalletLibraryVersionInfo(),
-            interceptors = httpInterceptors,
+            interceptors = httpInterceptors
         )
         return VerifiedIdClient(
             requestResolverFactory,

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/VerifiedIdClientBuilder.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/VerifiedIdClientBuilder.kt
@@ -8,6 +8,7 @@ package com.microsoft.walletlibrary
 import android.content.Context
 import com.microsoft.walletlibrary.did.sdk.VerifiableCredentialSdk
 import android.content.pm.PackageManager
+import com.microsoft.walletlibrary.interceptor.HttpInterceptor
 import com.microsoft.walletlibrary.requests.RequestHandlerFactory
 import com.microsoft.walletlibrary.requests.RequestResolverFactory
 import com.microsoft.walletlibrary.requests.handlers.OpenIdRequestHandler
@@ -33,6 +34,7 @@ class VerifiedIdClientBuilder(private val context: Context) {
     private var logger: WalletLibraryLogger = WalletLibraryLogger
     private val requestResolvers = mutableListOf<RequestResolver>()
     private val requestHandlers = mutableListOf<RequestHandler>()
+    private val httpInterceptors = mutableListOf<HttpInterceptor>()
     private val jsonSerializer = Json {
         serializersModule = SerializersModule {
             polymorphic(VerifiedId::class) {
@@ -51,6 +53,11 @@ class VerifiedIdClientBuilder(private val context: Context) {
         logger.addConsumer(logConsumer)
     }
 
+    fun with(httpInterceptor: HttpInterceptor): VerifiedIdClientBuilder {
+        httpInterceptors.add(httpInterceptor)
+        return this
+    }
+
     // Configures and returns VerifiedIdClient with the configurations provided in builder class.
     fun build(): VerifiedIdClient {
         val requestResolverFactory = RequestResolverFactory()
@@ -66,7 +73,8 @@ class VerifiedIdClientBuilder(private val context: Context) {
             context,
             logConsumer = vcSdkLogConsumer,
             userAgentInfo = getUserAgent(context),
-            walletLibraryVersionInfo = getWalletLibraryVersionInfo()
+            walletLibraryVersionInfo = getWalletLibraryVersionInfo(),
+            interceptors = httpInterceptors,
         )
         return VerifiedIdClient(
             requestResolverFactory,

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/VerifiableCredentialSdk.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/VerifiableCredentialSdk.kt
@@ -10,6 +10,7 @@ import com.microsoft.walletlibrary.did.sdk.di.DaggerSdkComponent
 import com.microsoft.walletlibrary.did.sdk.util.DifWordList
 import com.microsoft.walletlibrary.did.sdk.util.log.DefaultLogConsumer
 import com.microsoft.walletlibrary.did.sdk.util.log.SdkLog
+import com.microsoft.walletlibrary.interceptor.HttpInterceptor
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 
@@ -58,6 +59,7 @@ internal object VerifiableCredentialSdk {
      * @param polymorphicJsonSerializers serializer module
      * @param registrationUrl url used to register DID
      * @param resolverUrl url used to resolve DID
+     * @param interceptors HttpInterceptor to modify http request
      */
     // TODO(Change how version numbers are passed for headers when HTTP client layer is refactored)
     @JvmOverloads
@@ -69,7 +71,8 @@ internal object VerifiableCredentialSdk {
         polymorphicJsonSerializers: SerializersModule = Json.serializersModule,
         registrationUrl: String = "",
         resolverUrl: String = "https://discover.did.msidentity.com/v1.0/identifiers",
-        walletLibraryVersionInfo: String = ""
+        walletLibraryVersionInfo: String = "",
+        interceptors: List<HttpInterceptor> = emptyList()
     ) {
         val sdkComponent = DaggerSdkComponent.builder()
             .context(context)
@@ -78,6 +81,7 @@ internal object VerifiableCredentialSdk {
             .registrationUrl(registrationUrl)
             .resolverUrl(resolverUrl)
             .polymorphicJsonSerializer(polymorphicJsonSerializers)
+            .httpInterceptors(interceptors)
             .build()
 
         issuanceService = sdkComponent.issuanceService()

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/datasource/network/interceptors/ExternalInterceptor.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/datasource/network/interceptors/ExternalInterceptor.kt
@@ -48,6 +48,7 @@ class ExternalInterceptor constructor(private val httpInterceptors: List<HttpInt
         }
 
         val externalResponse = HttpResponse(
+            request = externalRequest,
             statusCode = response.code,
             statusMessage = response.message,
             headers = convertHeaders(response.headers).toImmutableMap()

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/datasource/network/interceptors/ExternalInterceptor.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/datasource/network/interceptors/ExternalInterceptor.kt
@@ -1,0 +1,73 @@
+package com.microsoft.walletlibrary.did.sdk.datasource.network.interceptors
+
+import com.microsoft.walletlibrary.interceptor.HttpInterceptor
+import com.microsoft.walletlibrary.interceptor.HttpRequest
+import com.microsoft.walletlibrary.interceptor.HttpResponse
+import com.microsoft.walletlibrary.interceptor.MutableHttpHeaders
+import okhttp3.Headers
+import okhttp3.Interceptor
+import okhttp3.Response
+import okhttp3.internal.toImmutableMap
+
+class ExternalInterceptor constructor(private val httpInterceptors: List<HttpInterceptor>) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        // short circuit if no external interceptors
+        if (httpInterceptors.isEmpty()) {
+            return chain.proceed(chain.request())
+        }
+
+        // convert to abstract request
+        val originalRequest = chain.request()
+        val externalRequest = HttpRequest(
+            uri = originalRequest.url.toString(),
+            method = originalRequest.method,
+            headers = this.convertHeaders(originalRequest.headers)
+        )
+
+        // allow each interceptor to mutate the headers
+        httpInterceptors.forEach {
+            it.beforeRequest(externalRequest)
+        }
+        // build a new request if required
+        val newBuilder = originalRequest.newBuilder()
+        var changed = false
+        externalRequest.headers.forEach { (header, value) ->
+            if (originalRequest.headers[header] != value) {
+                changed = true
+                newBuilder.header(header, value)
+            }
+        }
+
+        // make the http call
+        val response = if (changed) {
+            val newRequest = newBuilder.build()
+            chain.proceed(newRequest)
+        } else {
+            chain.proceed(originalRequest)
+        }
+
+        val externalResponse = HttpResponse(
+            statusCode = response.code,
+            statusMessage = response.message,
+            headers = convertHeaders(response.headers).toImmutableMap()
+        )
+
+        // notify interceptors of response
+        httpInterceptors.forEach {
+            it.onResponse(externalResponse)
+        }
+
+        return response
+    }
+
+    private fun convertHeaders(headers: Headers): MutableHttpHeaders {
+        val outputHeaders: MutableHttpHeaders = mutableMapOf()
+        headers.names().forEach { header ->
+            headers[header]?.let { value ->
+                outputHeaders[header] = value
+            }
+        }
+        return outputHeaders
+    }
+}

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/di/SdkComponent.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/di/SdkComponent.kt
@@ -13,6 +13,7 @@ import com.microsoft.walletlibrary.did.sdk.IssuanceService
 import com.microsoft.walletlibrary.did.sdk.LinkedDomainsService
 import com.microsoft.walletlibrary.did.sdk.PresentationService
 import com.microsoft.walletlibrary.did.sdk.RevocationService
+import com.microsoft.walletlibrary.interceptor.HttpInterceptor
 import dagger.BindsInstance
 import dagger.Component
 import kotlinx.serialization.modules.SerializersModule
@@ -66,5 +67,8 @@ internal interface SdkComponent {
 
         @BindsInstance
         fun polymorphicJsonSerializer(@Named("polymorphicJsonSerializer") jsonSerializer: SerializersModule): Builder
+
+        @BindsInstance
+        fun httpInterceptors(@Named("httpInterceptors") httpInterceptors: List<HttpInterceptor>): Builder
     }
 }

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/di/SdkModule.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/di/SdkModule.kt
@@ -19,11 +19,13 @@ import com.microsoft.walletlibrary.did.sdk.credential.service.validators.OidcPre
 import com.microsoft.walletlibrary.did.sdk.credential.service.validators.PresentationRequestValidator
 import com.microsoft.walletlibrary.did.sdk.datasource.db.SdkDatabase
 import com.microsoft.walletlibrary.did.sdk.datasource.network.interceptors.CorrelationVectorInterceptor
+import com.microsoft.walletlibrary.did.sdk.datasource.network.interceptors.ExternalInterceptor
 import com.microsoft.walletlibrary.did.sdk.datasource.network.interceptors.UserAgentInterceptor
 import com.microsoft.walletlibrary.did.sdk.datasource.network.interceptors.WalletLibraryHeaderInterceptor
 import com.microsoft.walletlibrary.did.sdk.identifier.registrars.Registrar
 import com.microsoft.walletlibrary.did.sdk.identifier.registrars.SidetreeRegistrar
 import com.microsoft.walletlibrary.did.sdk.util.log.SdkLog
+import com.microsoft.walletlibrary.interceptor.HttpInterceptor
 import dagger.Module
 import dagger.Provides
 import kotlinx.serialization.json.Json
@@ -59,6 +61,7 @@ internal class SdkModule {
     internal fun defaultOkHttpClient(
         @Named("userAgentInfo") userAgentInfo: String,
         @Named("walletLibraryVersionInfo") walletLibraryVersionInfo: String,
+        @Named("httpInterceptors") httpInterceptors: List<HttpInterceptor>,
         correlationVectorService: CorrelationVectorService
     ): OkHttpClient {
         val httpLoggingInterceptor = HttpLoggingInterceptor { SdkLog.d(it) }
@@ -69,6 +72,7 @@ internal class SdkModule {
             .addInterceptor(UserAgentInterceptor(userAgentInfo))
             .addInterceptor(WalletLibraryHeaderInterceptor(walletLibraryVersionInfo))
             .addInterceptor(CorrelationVectorInterceptor(correlationVectorService))
+            .addInterceptor(ExternalInterceptor(httpInterceptors))
             .build()
     }
 

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpHeaders.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpHeaders.kt
@@ -1,0 +1,8 @@
+package com.microsoft.walletlibrary.interceptor
+
+typealias MutableHttpHeaders = MutableMap<String, String>
+typealias HttpHeaders = Map<String, String>
+
+object HttpHeader {
+    val Prefer = "Prefer"
+}

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpHeaders.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpHeaders.kt
@@ -2,7 +2,3 @@ package com.microsoft.walletlibrary.interceptor
 
 typealias MutableHttpHeaders = MutableMap<String, String>
 typealias HttpHeaders = Map<String, String>
-
-object HttpHeader {
-    val Prefer = "Prefer"
-}

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpInterceptor.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpInterceptor.kt
@@ -4,7 +4,7 @@ package com.microsoft.walletlibrary.interceptor
  * Allows for hooking into http request events.
  * Inherit from this class and override functions to add hooks
  */
-class HttpInterceptor {
+open class HttpInterceptor {
 
     /**
      * Runs before an http request is made

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpInterceptor.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpInterceptor.kt
@@ -1,7 +1,24 @@
 package com.microsoft.walletlibrary.interceptor
 
-interface HttpInterceptor {
-    fun beforeRequest(Request: HttpRequest)
+/**
+ * Allows for hooking into http request events.
+ * Inherit from this class and override functions to add hooks
+ */
+class HttpInterceptor {
 
-    fun onResponse(Response: HttpResponse)
+    /**
+     * Runs before an http request is made
+     * @Param request the http request about to be made
+     */
+    fun beforeRequest(request: HttpRequest) {
+        // no-op
+    }
+
+    /**
+     * Runs after an http request is made
+     * @Param response the http request about to be made
+     */
+    fun onResponse(response: HttpResponse) {
+        // no-op
+    }
 }

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpInterceptor.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpInterceptor.kt
@@ -10,7 +10,7 @@ open class HttpInterceptor {
      * Runs before an http request is made
      * @Param request the http request about to be made
      */
-    fun beforeRequest(request: HttpRequest) {
+    open fun beforeRequest(request: HttpRequest) {
         // no-op
     }
 
@@ -18,7 +18,7 @@ open class HttpInterceptor {
      * Runs after an http request is made
      * @Param response the http request about to be made
      */
-    fun onResponse(response: HttpResponse) {
+    open fun onResponse(response: HttpResponse) {
         // no-op
     }
 }

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpInterceptor.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpInterceptor.kt
@@ -1,0 +1,7 @@
+package com.microsoft.walletlibrary.interceptor
+
+interface HttpInterceptor {
+    fun beforeRequest(Request: HttpRequest)
+
+    fun onResponse(Response: HttpResponse)
+}

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpRequest.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpRequest.kt
@@ -1,0 +1,18 @@
+package com.microsoft.walletlibrary.interceptor
+
+data class HttpRequest (
+    /**
+     * URI/URL of the request
+     */
+    val uri: String,
+
+    /**
+     * Http method of the request
+     */
+    val method: String,
+
+    /**
+     * Http Headers on the request
+     */
+    var headers: MutableHttpHeaders
+)

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpRequest.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpRequest.kt
@@ -1,6 +1,6 @@
 package com.microsoft.walletlibrary.interceptor
 
-data class HttpRequest (
+data class HttpRequest(
     /**
      * URI/URL of the request
      */

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpResponse.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpResponse.kt
@@ -1,0 +1,19 @@
+package com.microsoft.walletlibrary.interceptor
+
+data class HttpResponse (
+    /**
+     * Status Code
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+     */
+    val statusCode: Int,
+
+    /**
+     * Status message for the corresponding status code
+     */
+    val statusMessage: String,
+
+    /**
+     * Headers on the response
+     */
+    val headers: HttpHeaders
+)

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpResponse.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpResponse.kt
@@ -1,6 +1,6 @@
 package com.microsoft.walletlibrary.interceptor
 
-data class HttpResponse (
+data class HttpResponse(
     /**
      * original http request
      */

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpResponse.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/interceptor/HttpResponse.kt
@@ -2,8 +2,12 @@ package com.microsoft.walletlibrary.interceptor
 
 data class HttpResponse (
     /**
+     * original http request
+     */
+    val request: HttpRequest,
+
+    /**
      * Status Code
-     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
      */
     val statusCode: Int,
 


### PR DESCRIPTION
**Problem:**
Current Wallet library offers no means to inject custom request headers, time requests, or perform more advanced logging.

**Solution:**
Adds an abstraction for wallet developers to hook into requests before being sent and time responses.

**Validation:**
manually integrated testing

**Type of change:**
- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.