### PR TITLE
Creating a get-only public verifiedId variable on verifiedIdRequirement

### DIFF
--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/requirements/VerifiedIdRequirement.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/requirements/VerifiedIdRequirement.kt
@@ -39,8 +39,12 @@ class VerifiedIdRequirement(
     // Information needed for issuance from presentation.
     val issuanceOptions: List<VerifiedIdRequestInput> = mutableListOf(),
 
-    internal var verifiedId: VerifiedId? = null
+    internal var _verifiedId: VerifiedId? = null
 ) : Requirement {
+
+    val verifiedId: VerifiedId?
+        get() = this._verifiedId
+
     // Constraint that represents how the requirement is fulfilled
     internal var constraint: VerifiedIdConstraint = toVcTypeConstraint()
 
@@ -58,12 +62,12 @@ class VerifiedIdRequirement(
 
     // Validates the requirement and throws an exception if the requirement is invalid or not fulfilled.
     override fun validate(): VerifiedIdResult<Unit> {
-        if (verifiedId == null)
+        if (_verifiedId == null)
             return RequirementNotMetException(
                 "Verified ID has not been set.",
                 VerifiedIdExceptions.REQUIREMENT_NOT_MET_EXCEPTION.value
             ).toVerifiedIdResult()
-        verifiedId?.let {
+        _verifiedId?.let {
             try {
                 constraint.matches(it)
             } catch (constraintException: RequirementValidationException) {
@@ -88,7 +92,7 @@ class VerifiedIdRequirement(
                 listOf(constraintException)
             ).toVerifiedIdResult()
         }
-        verifiedId = selectedVerifiedId
+        _verifiedId = selectedVerifiedId
         return VerifiedIdResult.success(Unit)
     }
 

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/requirements/VerifiedIdRequirement.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/requirements/VerifiedIdRequirement.kt
@@ -42,6 +42,7 @@ class VerifiedIdRequirement(
     internal var _verifiedId: VerifiedId? = null
 ) : Requirement {
 
+    // Readonly Verified ID that is currently fulfilling the requirement (if any)
     val verifiedId: VerifiedId?
         get() = this._verifiedId
 

--- a/walletlibrary/src/test/java/com/microsoft/walletlibrary/did/sdk/credential/service/protectors/PresentationResponseFormatterTest.kt
+++ b/walletlibrary/src/test/java/com/microsoft/walletlibrary/did/sdk/credential/service/protectors/PresentationResponseFormatterTest.kt
@@ -180,7 +180,7 @@ class PresentationResponseFormatterTest {
         response.addRequirements(VerifiedIdRequirement(
             firstInputDefinitionId,
             types = listOf(firstVpTokenType),
-            verifiedId = walletCredentialOne
+            _verifiedId = walletCredentialOne
         ))
         val responses = listOf(response)
 
@@ -267,7 +267,7 @@ class PresentationResponseFormatterTest {
         responseOne.addRequirements(VerifiedIdRequirement(
             firstInputDefinitionId,
             types = listOf(firstVpTokenType),
-            verifiedId = walletCredentialOne
+            _verifiedId = walletCredentialOne
         ))
         val responseTwo =
             PresentationResponse(
@@ -277,7 +277,7 @@ class PresentationResponseFormatterTest {
         responseTwo.addRequirements(VerifiedIdRequirement(
             secondInputDefinitionId,
             types = listOf(secondVpTokenType),
-            verifiedId = walletCredentialTwo
+            _verifiedId = walletCredentialTwo
         ))
         val responses = listOf(responseOne, responseTwo)
 
@@ -374,12 +374,12 @@ class PresentationResponseFormatterTest {
         responseOne.addRequirements(VerifiedIdRequirement(
             firstInputDefinitionId,
             types = listOf(firstVpTokenType),
-            verifiedId = walletCredentialOne
+            _verifiedId = walletCredentialOne
         ))
         responseOne.addRequirements(VerifiedIdRequirement(
             secondInputDefinitionId,
             types = listOf(secondVpTokenType),
-            verifiedId = walletCredentialTwo
+            _verifiedId = walletCredentialTwo
         ))
         val responses = listOf(responseOne)
 

--- a/walletlibrary/src/test/java/com/microsoft/walletlibrary/mappings/issuance/IssuanceResponseMappingTest.kt
+++ b/walletlibrary/src/test/java/com/microsoft/walletlibrary/mappings/issuance/IssuanceResponseMappingTest.kt
@@ -231,7 +231,7 @@ class IssuanceResponseMappingTest {
         val mockVerifiableCredential: VerifiableCredential = mockk()
         every { mockVerifiableCredential.raw } returns mockk()
         every { mockVerifiableCredential.types } returns listOf(expectedCredentialType)
-        verifiedIdRequirement.verifiedId = mockVerifiableCredential
+        verifiedIdRequirement._verifiedId = mockVerifiableCredential
         val mockPresentationAttestation: PresentationAttestation = mockk()
         every { mockIssuanceRequest.getAttestations().presentations } returns listOf(mockPresentationAttestation)
         every { mockPresentationAttestation.credentialType } returns expectedCredentialType

--- a/walletlibrary/src/test/java/com/microsoft/walletlibrary/requests/requirements/VerifiedIdRequirementTest.kt
+++ b/walletlibrary/src/test/java/com/microsoft/walletlibrary/requests/requirements/VerifiedIdRequirementTest.kt
@@ -45,6 +45,8 @@ class VerifiedIdRequirementTest {
         verifiedIdRequirement.fulfill(expectedVerifiedId)
 
         // Assert
+        assertThat(verifiedIdRequirement._verifiedId).isNotNull
+        assertThat(verifiedIdRequirement._verifiedId).isEqualTo(expectedVerifiedId)
         assertThat(verifiedIdRequirement.verifiedId).isNotNull
         assertThat(verifiedIdRequirement.verifiedId).isEqualTo(expectedVerifiedId)
     }


### PR DESCRIPTION
**Problem:**
There is no easy way to retrieve data about what credential fulfilled a requirement.


**Solution:**
Exposes verifiedId as a getter field to make reading this data easy. Still has to be set with the fulfill function.


**Validation:**
Manually integration tested with Authenticator. Unit tests use the getter value but the simple unit test has been updated for the internal variable as well.


**Type of change:**
- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:


**Documentation Links**: