### PR TITLE
When a root of trust resolver is injected, use it as default resolver to fetch the linked domains.

### DIFF
--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/VerifiedIdClient.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/VerifiedIdClient.kt
@@ -38,7 +38,7 @@ class VerifiedIdClient(
         return getResult {
             VerifiableCredentialSdk.correlationVectorService.startNewFlowAndSave()
             val requestResolver = requestResolverFactory.getResolver(verifiedIdRequestInput)
-            val rawRequest = requestResolver.resolve(verifiedIdRequestInput)
+            val rawRequest = requestResolver.resolve(verifiedIdRequestInput, rootOfTrustResolver)
             val requestHandler = requestProcessorFactory.getHandler(rawRequest)
             requestHandler.handleRequest(rawRequest, rootOfTrustResolver)
         }

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/PresentationService.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/PresentationService.kt
@@ -50,16 +50,16 @@ internal class PresentationService @Inject constructor(
             logTime("Presentation getRequest") {
                 val uri = verifyUri(stringUri)
                 val (presentationRequestContent, rawContent) = getPresentationRequestContent(uri, preferHeaders).abortOnError()
-                val request = validateRequest(presentationRequestContent).abortOnError()
+                val request = validateRequest(presentationRequestContent, rootOfTrustResolver).abortOnError()
                 return@logTime Result.Success(Pair(request, rawContent))
             }
         }
     }
 
-    internal suspend fun validateRequest(presentationRequestContent: PresentationRequestContent): Result<PresentationRequest> {
+    internal suspend fun validateRequest(presentationRequestContent: PresentationRequestContent, rootOfTrustResolver: RootOfTrustResolver? = null): Result<PresentationRequest> {
         return runResultTry {
             logTime("Presentation validateRequest") {
-                val linkedDomainResult = linkedDomainsService.fetchAndVerifyLinkedDomains(presentationRequestContent.clientId).toSDK().abortOnError()
+                val linkedDomainResult = linkedDomainsService.fetchAndVerifyLinkedDomains(presentationRequestContent.clientId, rootOfTrustResolver).toSDK().abortOnError()
                 val request = PresentationRequest(presentationRequestContent, linkedDomainResult)
                 isRequestValid(request).abortOnError()
                 Result.Success(request)


### PR DESCRIPTION
**Problem:**
When a root of trust resolvers is being injected, it was not being passed down to underlying layer and used to resolve the linked domains. In cases where the injected resolver is the only option, fall back option didn't work.


**Solution:**
Pass the injected root of resolver to underlying layers to be used to resolve the linked domains.


**Validation:**
Manually tested all the flows including the failing scenario to verify they all pass.


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.