### PR TITLE
Error handling for PIN failures in pre-auth flow

### DIFF
--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/util/controlflow/Exceptions.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/util/controlflow/Exceptions.kt
@@ -99,7 +99,7 @@ class RedirectException(message: String, retryable: Boolean) : NetworkException(
 
 class ExpiredTokenException(message: String, retryable: Boolean) : NetworkException(message, retryable)
 
-class InvalidPinException(message: String, retryable: Boolean) : NetworkException(message, retryable)
+class InvalidPinException(message: String, retryable: Boolean, val attemptsLeft: Int? = null) : NetworkException(message, retryable)
 
 class RepositoryException(message: String, cause: Throwable? = null) : SdkException(message, cause)
 

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/util/controlflow/Exceptions.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/util/controlflow/Exceptions.kt
@@ -99,7 +99,7 @@ class RedirectException(message: String, retryable: Boolean) : NetworkException(
 
 class ExpiredTokenException(message: String, retryable: Boolean) : NetworkException(message, retryable)
 
-class InvalidPinException(message: String, retryable: Boolean, val attemptsLeft: Int? = null) : NetworkException(message, retryable)
+class InvalidPinException(message: String, retryable: Boolean) : NetworkException(message, retryable)
 
 class RepositoryException(message: String, cause: Throwable? = null) : SdkException(message, cause)
 

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/requirements/OpenId4VCIPinRequirement.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/requirements/OpenId4VCIPinRequirement.kt
@@ -2,7 +2,9 @@ package com.microsoft.walletlibrary.requests.requirements
 
 import com.microsoft.walletlibrary.requests.resolvers.OpenID4VCIPreAuthAccessTokenResolver
 import com.microsoft.walletlibrary.util.LibraryConfiguration
+import com.microsoft.walletlibrary.util.NetworkingException
 import com.microsoft.walletlibrary.util.RequirementNotMetException
+import com.microsoft.walletlibrary.util.VerifiedIdException
 import com.microsoft.walletlibrary.util.VerifiedIdExceptions
 import com.microsoft.walletlibrary.util.VerifiedIdResult
 import com.microsoft.walletlibrary.util.getResult
@@ -28,11 +30,11 @@ class OpenId4VCIPinRequirement(
         return VerifiedIdResult.success(Unit)
     }
 
-    suspend fun fulfill(pin: String) {
+    suspend fun fulfill(pin: String): VerifiedIdResult<Unit> {
         this.pin = pin
-        libraryConfiguration?.let { libraryConfiguration ->
-            accessTokenEndpoint?.let {
-                getResult {
+        return getResult {
+            libraryConfiguration?.let { libraryConfiguration ->
+                accessTokenEndpoint?.let {
                     OpenID4VCIPreAuthAccessTokenResolver(libraryConfiguration).resolve(preAuthorizedCode, this, it)
                 }
             }

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/resolvers/OpenID4VCIPreAuthAccessTokenResolver.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/resolvers/OpenID4VCIPreAuthAccessTokenResolver.kt
@@ -3,15 +3,13 @@
 package com.microsoft.walletlibrary.requests.resolvers
 
 import com.microsoft.walletlibrary.did.sdk.util.controlflow.ForbiddenException
-import com.microsoft.walletlibrary.did.sdk.util.controlflow.InvalidPinException
 import com.microsoft.walletlibrary.networking.entities.openid4vci.request.OpenID4VCIPreAuthTokenRequest
 import com.microsoft.walletlibrary.networking.operations.PostOpenID4VCIPreAuthNetworkOperation
 import com.microsoft.walletlibrary.requests.requirements.OpenId4VCIPinRequirement
+import com.microsoft.walletlibrary.util.InvalidPinAttemptException
 import com.microsoft.walletlibrary.util.LibraryConfiguration
-import com.microsoft.walletlibrary.util.NetworkingException
-import com.microsoft.walletlibrary.util.OpenId4VciRequestException
 import com.microsoft.walletlibrary.util.OpenId4VciValidationException
-import com.microsoft.walletlibrary.util.RequirementValidationException
+import com.microsoft.walletlibrary.util.RequirementNotMetException
 import com.microsoft.walletlibrary.util.VerifiedIdExceptions
 
 internal class OpenID4VCIPreAuthAccessTokenResolver(val libraryConfiguration: LibraryConfiguration) {
@@ -53,13 +51,15 @@ internal class OpenID4VCIPreAuthAccessTokenResolver(val libraryConfiguration: Li
             .onFailure {
                 var innerException = it as Exception
 
+                // PIN related errors are 403.
                 if (it is ForbiddenException) {
                     // Based on error message, determine if the error is retriable and how many more times.
                     it.errorBody?.let { errorBody ->
                         pinMismatchRegex.find(errorBody)?.let { match ->
                             match.groups[1]?.value?.toIntOrNull()?.let { attempts ->
-                                innerException = InvalidPinException(
+                                innerException = InvalidPinAttemptException(
                                     "Entered PIN does not match expectations.",
+                                    it,
                                     attempts > 0,
                                     attempts
                                 )
@@ -68,18 +68,18 @@ internal class OpenID4VCIPreAuthAccessTokenResolver(val libraryConfiguration: Li
                     }
 
                     // Even if no more attempts are possible, forbidden means a PIN error.
-                    if (innerException !is InvalidPinException) {
-                        innerException = InvalidPinException(
+                    if (innerException !is InvalidPinAttemptException) {
+                        innerException = InvalidPinAttemptException(
                             "Failed to validate PIN.",
-                            false
+                            it
                         )
                     }
                 }
 
-                throw RequirementValidationException(
+                throw RequirementNotMetException(
                     "Failed to fetch access token for Pre Auth flow",
-                    innerException,
-                    (innerException as? InvalidPinException)?.retryable ?: false
+                    VerifiedIdExceptions.REQUIREMENT_NOT_MET_EXCEPTION.value,
+                    listOf(innerException)
                 )
             }
     }

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/Exceptions.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/Exceptions.kt
@@ -197,3 +197,10 @@ class IdInVerifiedIdRequirementDoesNotMatchRequestException(
     cause: Throwable? = null,
     retryable: Boolean = false
 ) : RequirementValidationException(message, cause, retryable)
+
+class InvalidPinAttemptException(
+    message: String = "",
+    cause: Throwable? = null,
+    retryable: Boolean = false,
+    val attemptsLeft: Int? = null
+) : RequirementValidationException(message, cause, retryable)


### PR DESCRIPTION
**Problem:**
PIN errors did not bubble up in pre-auth flow.


**Solution:**
Add error handling as well as attempts parsing in PIN failures for pre-auth flow.


**Validation:**
-Unit tests
-Manual e2e tests

**Type of change:**
- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3046468