### PR TITLE
Error handling for PIN failures in pre-auth flow

### DIFF
--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/requirements/OpenId4VCIPinRequirement.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/requirements/OpenId4VCIPinRequirement.kt
@@ -42,16 +42,12 @@ class OpenId4VCIPinRequirement(
         return null
     }
 
-    suspend fun fulfill(pin: String) {
+    suspend fun fulfill(pin: String): VerifiedIdResult<Unit> {
         this.pin = pin
-        libraryConfiguration?.let { libraryConfiguration ->
-            accessTokenEndpoint?.let {
-                getResult {
-                    OpenID4VCIPreAuthAccessTokenResolver(libraryConfiguration).resolve(
-                        preAuthorizedCode,
-                        this,
-                        it
-                    )
+        return getResult {
+            libraryConfiguration?.let { libraryConfiguration ->
+                accessTokenEndpoint?.let {
+                    OpenID4VCIPreAuthAccessTokenResolver(libraryConfiguration).resolve(preAuthorizedCode, this, it)
                 }
             }
         }

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/resolvers/OpenID4VCIPreAuthAccessTokenResolver.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/resolvers/OpenID4VCIPreAuthAccessTokenResolver.kt
@@ -5,15 +5,22 @@ package com.microsoft.walletlibrary.requests.resolvers
 import com.microsoft.walletlibrary.networking.entities.openid4vci.request.OpenID4VCIPreAuthTokenRequest
 import com.microsoft.walletlibrary.networking.operations.PostOpenID4VCIPreAuthNetworkOperation
 import com.microsoft.walletlibrary.requests.requirements.OpenId4VCIPinRequirement
+import com.microsoft.walletlibrary.util.InvalidPinAttemptException
 import com.microsoft.walletlibrary.util.LibraryConfiguration
+import com.microsoft.walletlibrary.util.NetworkingException
 import com.microsoft.walletlibrary.util.OpenId4VciRequestException
 import com.microsoft.walletlibrary.util.OpenId4VciValidationException
+import com.microsoft.walletlibrary.util.RequirementNotMetException
 import com.microsoft.walletlibrary.util.VerifiedIdExceptions
 
 /**
  * Resolves and fulfills the access token for Pre Auth flow.
  */
 internal class OpenID4VCIPreAuthAccessTokenResolver(val libraryConfiguration: LibraryConfiguration) {
+    companion object {
+        private val pinMismatchRegex = "Invalid PIN\\. You can try ([0-9]+) more times\\.".toRegex()
+    }
+
     suspend fun resolve(
         preAuthorizedCode: String?,
         openId4VCIPinRequirement: OpenId4VCIPinRequirement,
@@ -46,10 +53,36 @@ internal class OpenID4VCIPreAuthAccessTokenResolver(val libraryConfiguration: Li
                 )
             }
             .onFailure {
-                throw OpenId4VciRequestException(
+                var innerException = it as Exception
+
+                if ((it as? NetworkingException)?.statusCode == "403") {
+                    // Based on error message, determine if the error is retriable and how many more times.
+                    it.errorBody?.let { errorBody ->
+                        pinMismatchRegex.find(errorBody)?.let { match ->
+                            match.groups[1]?.value?.toIntOrNull()?.let { attempts ->
+                                innerException = InvalidPinAttemptException(
+                                    "Entered PIN does not match expectations.",
+                                    it,
+                                    attempts > 0,
+                                    attempts
+                                )
+                            }
+                        }
+                    }
+
+                    // Even if no more attempts are possible, forbidden means a PIN error.
+                    if (innerException !is InvalidPinAttemptException) {
+                        innerException = InvalidPinAttemptException(
+                            "Failed to validate PIN.",
+                            it
+                        )
+                    }
+                }
+
+                throw RequirementNotMetException(
                     "Failed to fetch access token for Pre Auth flow",
                     VerifiedIdExceptions.REQUEST_CREATION_EXCEPTION.value,
-                    it as Exception
+                    listOf(innerException)
                 )
             }
     }

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/Exceptions.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/Exceptions.kt
@@ -197,3 +197,10 @@ class IdInVerifiedIdRequirementDoesNotMatchRequestException(
     cause: Throwable? = null,
     retryable: Boolean = false
 ) : RequirementValidationException(message, cause, retryable)
+
+class InvalidPinAttemptException(
+    message: String = "",
+    cause: Throwable? = null,
+    retryable: Boolean = false,
+    val attemptsLeft: Int? = null
+) : RequirementValidationException(message, cause, retryable)


### PR DESCRIPTION
**Problem:**
PIN errors did not bubble up in pre-auth flow.


**Solution:**
Add error handling as well as attempts parsing in PIN failures for pre-auth flow.


**Validation:**
-Unit tests
-Manual e2e tests


**Type of change:**
- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)