### PR TITLE
Add logging during failures in linked domains validation.

### DIFF
--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/LinkedDomainsService.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/LinkedDomainsService.kt
@@ -37,24 +37,35 @@ internal class LinkedDomainsService @Inject constructor(
             rootOfTrustResolver?.resolve(identifierDocument)
                 ?.let { Result.success(it.toLinkedDomainResult()) }
                 ?: throw SdkException("Root of trust resolver is not configured")
-        } catch (ex: SdkException) {
-            SdkLog.i(
+        } catch (ex: Exception) {
+            SdkLog.w(
                 "Linked Domains verification using resolver failed with exception $ex. " +
-                        "Verifying it using Well Known Document.",
+                    "Verifying it using Well Known Document.",
                 ex
             )
-            val linkedDomains = verifyLinkedDomainsUsingWellKnownDocument(identifierDocument)
-            Result.success(linkedDomains)
-        } catch (ex: Exception) {
-            SdkLog.e("Linked Domains verification failed with exception $ex", ex)
-            Result.success(LinkedDomainMissing)
+            try {
+                val linkedDomains = verifyLinkedDomainsUsingWellKnownDocument(identifierDocument)
+                Result.success(linkedDomains)
+            } catch (ex: Exception) {
+                SdkLog.w("Linked Domains verification failed with exception $ex", ex)
+                Result.success(LinkedDomainMissing)
+            }
         }
     }
 
     suspend fun fetchDocumentAndVerifyLinkedDomains(relyingPartyDid: String): Result<LinkedDomainResult> {
         resolveIdentifierDocument(relyingPartyDid)
-            .onSuccess { return validateLinkedDomains(it) }
-            .onFailure { return Result.failure(it) }
+            .onSuccess {
+                val linkedDomainsValidationResult = validateLinkedDomains(it)
+                if (linkedDomainsValidationResult.isFailure)
+                    SdkLog.w("Linked Domains validation failed")
+                return linkedDomainsValidationResult
+            }
+            .onFailure {
+                SdkLog.w("Failed to fetch identifier document because of ${it.message}", it)
+                return Result.failure(it)
+            }
+        SdkLog.w("Failed to fetch identifier document.")
         return Result.failure(SdkException("Failed to fetch identifier document"))
     }
 
@@ -89,7 +100,7 @@ internal class LinkedDomainsService @Inject constructor(
                 }
             }
             .onFailure {
-                SdkLog.i("Unable to fetch well-known config document from $domainUrl because of ${it.message}")
+                SdkLog.w("Unable to fetch well-known config document from $domainUrl because of ${it.message}")
                 return Result.success(LinkedDomainUnVerified(hostname))
             }
         return Result.success(LinkedDomainMissing)


### PR DESCRIPTION
If the injected root of resolver fails resolving the domains, use the well-known configuration as fallback and log the failures.


**Validation:**
Manually verified the flow.


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.