### PR TITLE
Use the wrapper for linked domains validation which uses the injected root of trust resolver and fallback option.

### DIFF
--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/LinkedDomainsService.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/LinkedDomainsService.kt
@@ -20,6 +20,7 @@ import java.net.URL
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
 
 @Singleton
 internal class LinkedDomainsService @Inject constructor(
@@ -37,6 +38,9 @@ internal class LinkedDomainsService @Inject constructor(
             rootOfTrustResolver?.resolve(identifierDocument)
                 ?.let { Result.success(it.toLinkedDomainResult()) }
                 ?: throw SdkException("Root of trust resolver is not configured")
+        } catch (ex: CancellationException) {
+          SdkLog.w("Linked Domains verification using resolver failed with exception $ex. $ex")
+          throw ex
         } catch (ex: Exception) {
             SdkLog.w(
                 "Linked Domains verification using resolver failed with exception $ex. " +

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/handlers/SignedMetadataProcessor.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/handlers/SignedMetadataProcessor.kt
@@ -48,8 +48,7 @@ internal class SignedMetadataProcessor(private val libraryConfiguration: Library
         validateSignedMetadata(jwsToken, jwk, credentialIssuer, did)
 
         // Return the root of trust from the identifier document along with its verification status.
-        val rootOfTrustResolver = libraryConfiguration.rootOfTrustResolver ?: LinkedDomainsResolver
-        return rootOfTrustResolver.resolve(identifierDocument)
+        return LinkedDomainsResolver.resolve(identifierDocument)
     }
 
     private fun deserializeSignedMetadata(signedMetadata: String): JwsToken {

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/wrapper/LinkedDomainsResolver.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/wrapper/LinkedDomainsResolver.kt
@@ -21,10 +21,13 @@ internal object LinkedDomainsResolver : RootOfTrustResolver {
                 VerifiedIdExceptions.MALFORMED_INPUT_EXCEPTION.value
             )
         }
-        VerifiableCredentialSdk.linkedDomainsService.validateLinkedDomains(didMetadata)
+        val linkedDomainsService = getLinkedDomainsService()
+        linkedDomainsService.validateLinkedDomains(didMetadata)
             .map { it.toRootOfTrust() }
             .onSuccess { return it }
             .onFailure { return RootOfTrust("", false) }
         return RootOfTrust("", false)
     }
+
+    private fun getLinkedDomainsService() = VerifiableCredentialSdk.linkedDomainsService
 }

--- a/walletlibrary/src/test/java/com/microsoft/walletlibrary/did/sdk/LinkedDomainsServiceTest.kt
+++ b/walletlibrary/src/test/java/com/microsoft/walletlibrary/did/sdk/LinkedDomainsServiceTest.kt
@@ -10,6 +10,7 @@ import com.microsoft.walletlibrary.did.sdk.credential.service.validators.JwtDoma
 import com.microsoft.walletlibrary.did.sdk.credential.service.validators.JwtValidator
 import com.microsoft.walletlibrary.did.sdk.di.defaultTestSerializer
 import com.microsoft.walletlibrary.did.sdk.identifier.models.identifierdocument.DidMetadata
+import com.microsoft.walletlibrary.did.sdk.identifier.models.identifierdocument.IdentifierDocument
 import com.microsoft.walletlibrary.did.sdk.identifier.models.identifierdocument.IdentifierResponse
 import com.microsoft.walletlibrary.did.sdk.identifier.resolvers.MockRootOfTrustResolver
 import com.microsoft.walletlibrary.did.sdk.identifier.resolvers.Resolver
@@ -17,6 +18,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.spyk
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -30,6 +32,95 @@ class LinkedDomainsServiceTest {
         JwtDomainLinkageCredentialValidator(mockedJwtValidator, defaultTestSerializer)
     private val linkedDomainsService: LinkedDomainsService =
         spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator))
+
+    @Test
+    fun `injected root of trust resolver returns valid linked domain result`() {
+        val linkedDomainsService: LinkedDomainsService =
+            spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, MockInjectedRootOfTrustResolver()))
+        val mockIdentifierDocument = IdentifierDocument(id = MockDidMetadata.VALID_DOMAIN_DID.value)
+
+        runBlocking {
+            val linkedDomainsResult = linkedDomainsService.validateLinkedDomains(mockIdentifierDocument)
+            assertThat(linkedDomainsResult.isSuccess).isTrue
+            assertThat(linkedDomainsResult.getOrNull()).isInstanceOf(LinkedDomainVerified::class.java)
+            assertThat((linkedDomainsResult.getOrNull() as LinkedDomainVerified).domainUrl).isEqualTo("validDomain")
+        }
+    }
+
+    @Test
+    fun `injected root of trust resolver returns empty domain and well-known config is not setup returns missing linked domain result`() {
+        val linkedDomainsService: LinkedDomainsService =
+            spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, MockInjectedRootOfTrustResolver()), recordPrivateCalls = true)
+        val mockIdentifierDocument = IdentifierDocument(id = MockDidMetadata.EMPTY_DOMAIN_DID.value)
+
+        runBlocking {
+            val linkedDomainsResult = linkedDomainsService.validateLinkedDomains(mockIdentifierDocument)
+            assertThat(linkedDomainsResult.isSuccess).isTrue
+            assertThat(linkedDomainsResult.getOrNull()).isInstanceOf(LinkedDomainMissing::class.java)
+        }
+        coVerify { linkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) }
+    }
+
+    @Test
+    fun `injected root of trust resolver fails and well-known config is not setup returns missing linked domain result`() {
+        val linkedDomainsService: LinkedDomainsService =
+            spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, MockInjectedRootOfTrustResolver()), recordPrivateCalls = true)
+        val mockIdentifierDocument = IdentifierDocument(id = "failure")
+
+        runBlocking {
+            val linkedDomainsResult = linkedDomainsService.validateLinkedDomains(mockIdentifierDocument)
+            assertThat(linkedDomainsResult.isSuccess).isTrue
+            assertThat(linkedDomainsResult.getOrNull()).isInstanceOf(LinkedDomainMissing::class.java)
+        }
+        coVerify { linkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) }
+    }
+
+    @Test
+    fun `injected root of trust resolver fails or returns empty and well-known config returns valid linked domain`() {
+        val linkedDomainsService: LinkedDomainsService =
+            spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, MockInjectedRootOfTrustResolver()), recordPrivateCalls = true)
+        val mockIdentifierDocument = IdentifierDocument(id = "failure")
+        coEvery { linkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) } returns LinkedDomainVerified("testdomain")
+
+        runBlocking {
+            val linkedDomainsResult = linkedDomainsService.validateLinkedDomains(mockIdentifierDocument)
+            assertThat(linkedDomainsResult.isSuccess).isTrue
+            assertThat(linkedDomainsResult.getOrNull()).isInstanceOf(LinkedDomainVerified::class.java)
+            assertThat((linkedDomainsResult.getOrNull() as LinkedDomainVerified).domainUrl).isEqualTo("testdomain")
+        }
+        coVerify { linkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) }
+    }
+
+    @Test
+    fun `injected root of trust resolver fails or returns empty and well-known config returns invalid linked domain`() {
+        val linkedDomainsService: LinkedDomainsService =
+            spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, MockInjectedRootOfTrustResolver()), recordPrivateCalls = true)
+        val mockIdentifierDocument = IdentifierDocument(id = "failure")
+        coEvery { linkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) } returns LinkedDomainUnVerified("testdomain")
+
+        runBlocking {
+            val linkedDomainsResult = linkedDomainsService.validateLinkedDomains(mockIdentifierDocument)
+            assertThat(linkedDomainsResult.isSuccess).isTrue
+            assertThat(linkedDomainsResult.getOrNull()).isInstanceOf(LinkedDomainUnVerified::class.java)
+            assertThat((linkedDomainsResult.getOrNull() as LinkedDomainUnVerified).domainUrl).isEqualTo("testdomain")
+        }
+        coVerify { linkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) }
+    }
+
+    @Test
+    fun `injected root of trust resolver fails or returns empty and well-known config fails returns missing Linked Domain Result`() {
+        val linkedDomainsService: LinkedDomainsService =
+            spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, MockInjectedRootOfTrustResolver()), recordPrivateCalls = true)
+        val mockIdentifierDocument = IdentifierDocument(id = "failure")
+        coEvery { linkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) } throws Exception()
+
+        runBlocking {
+            val linkedDomainsResult = linkedDomainsService.validateLinkedDomains(mockIdentifierDocument)
+            assertThat(linkedDomainsResult.isSuccess).isTrue
+            assertThat(linkedDomainsResult.getOrNull()).isInstanceOf(LinkedDomainMissing::class.java)
+        }
+        coVerify { linkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) }
+    }
 
     @Test
     fun `test linked domains with single domain as string successfully`() {

--- a/walletlibrary/src/test/java/com/microsoft/walletlibrary/did/sdk/LinkedDomainsServiceTest.kt
+++ b/walletlibrary/src/test/java/com/microsoft/walletlibrary/did/sdk/LinkedDomainsServiceTest.kt
@@ -18,7 +18,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.spyk
-import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -36,7 +35,14 @@ class LinkedDomainsServiceTest {
     @Test
     fun `injected root of trust resolver returns valid linked domain result`() {
         val linkedDomainsService: LinkedDomainsService =
-            spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, MockInjectedRootOfTrustResolver()))
+            spyk(
+                LinkedDomainsService(
+                    mockk(relaxed = true),
+                    mockedResolver,
+                    mockedJwtDomainLinkageCredentialValidator,
+                    MockInjectedRootOfTrustResolver()
+                )
+            )
         val mockIdentifierDocument = IdentifierDocument(id = MockDidMetadata.VALID_DOMAIN_DID.value)
 
         runBlocking {
@@ -50,7 +56,14 @@ class LinkedDomainsServiceTest {
     @Test
     fun `injected root of trust resolver returns empty domain and well-known config is not setup returns missing linked domain result`() {
         val linkedDomainsService: LinkedDomainsService =
-            spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, MockInjectedRootOfTrustResolver()), recordPrivateCalls = true)
+            spyk(
+                LinkedDomainsService(
+                    mockk(relaxed = true),
+                    mockedResolver,
+                    mockedJwtDomainLinkageCredentialValidator,
+                    MockInjectedRootOfTrustResolver()
+                ), recordPrivateCalls = true
+            )
         val mockIdentifierDocument = IdentifierDocument(id = MockDidMetadata.EMPTY_DOMAIN_DID.value)
 
         runBlocking {
@@ -64,7 +77,14 @@ class LinkedDomainsServiceTest {
     @Test
     fun `injected root of trust resolver fails and well-known config is not setup returns missing linked domain result`() {
         val linkedDomainsService: LinkedDomainsService =
-            spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, MockInjectedRootOfTrustResolver()), recordPrivateCalls = true)
+            spyk(
+                LinkedDomainsService(
+                    mockk(relaxed = true),
+                    mockedResolver,
+                    mockedJwtDomainLinkageCredentialValidator,
+                    MockInjectedRootOfTrustResolver()
+                ), recordPrivateCalls = true
+            )
         val mockIdentifierDocument = IdentifierDocument(id = "failure")
 
         runBlocking {
@@ -78,7 +98,14 @@ class LinkedDomainsServiceTest {
     @Test
     fun `injected root of trust resolver fails or returns empty and well-known config returns valid linked domain`() {
         val linkedDomainsService: LinkedDomainsService =
-            spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, MockInjectedRootOfTrustResolver()), recordPrivateCalls = true)
+            spyk(
+                LinkedDomainsService(
+                    mockk(relaxed = true),
+                    mockedResolver,
+                    mockedJwtDomainLinkageCredentialValidator,
+                    MockInjectedRootOfTrustResolver()
+                ), recordPrivateCalls = true
+            )
         val mockIdentifierDocument = IdentifierDocument(id = "failure")
         coEvery { linkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) } returns LinkedDomainVerified("testdomain")
 
@@ -94,9 +121,18 @@ class LinkedDomainsServiceTest {
     @Test
     fun `injected root of trust resolver fails or returns empty and well-known config returns invalid linked domain`() {
         val linkedDomainsService: LinkedDomainsService =
-            spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, MockInjectedRootOfTrustResolver()), recordPrivateCalls = true)
+            spyk(
+                LinkedDomainsService(
+                    mockk(relaxed = true),
+                    mockedResolver,
+                    mockedJwtDomainLinkageCredentialValidator,
+                    MockInjectedRootOfTrustResolver()
+                ), recordPrivateCalls = true
+            )
         val mockIdentifierDocument = IdentifierDocument(id = "failure")
-        coEvery { linkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) } returns LinkedDomainUnVerified("testdomain")
+        coEvery { linkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) } returns LinkedDomainUnVerified(
+            "testdomain"
+        )
 
         runBlocking {
             val linkedDomainsResult = linkedDomainsService.validateLinkedDomains(mockIdentifierDocument)
@@ -110,7 +146,14 @@ class LinkedDomainsServiceTest {
     @Test
     fun `injected root of trust resolver fails or returns empty and well-known config fails returns missing Linked Domain Result`() {
         val linkedDomainsService: LinkedDomainsService =
-            spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, MockInjectedRootOfTrustResolver()), recordPrivateCalls = true)
+            spyk(
+                LinkedDomainsService(
+                    mockk(relaxed = true),
+                    mockedResolver,
+                    mockedJwtDomainLinkageCredentialValidator,
+                    MockInjectedRootOfTrustResolver()
+                ), recordPrivateCalls = true
+            )
         val mockIdentifierDocument = IdentifierDocument(id = "failure")
         coEvery { linkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) } throws Exception()
 
@@ -136,14 +179,19 @@ class LinkedDomainsServiceTest {
             defaultTestSerializer.decodeFromString(LinkedDomainsResponse.serializer(), expectedWellKnownConfigDocumentResponse)
         val expectedDomainUrl = "https://issuertestng.com"
         val hostnameOfUrl = URI(expectedDomainUrl).host
-        coEvery { linkedDomainsService.resolveIdentifierDocument(suppliedDidWithSingleServiceEndpoint) } returns KotlinResult.success(expectedResponse.didDocument)
-        coEvery { linkedDomainsService["getWellKnownConfigDocument"](expectedDomainUrl) } returns KotlinResult.success(expectedWellKnownConfigDocument)
+        coEvery { linkedDomainsService.resolveIdentifierDocument(suppliedDidWithSingleServiceEndpoint) } returns KotlinResult.success(
+            expectedResponse.didDocument
+        )
+        coEvery { linkedDomainsService["getWellKnownConfigDocument"](expectedDomainUrl) } returns KotlinResult.success(
+            expectedWellKnownConfigDocument
+        )
         coEvery { mockedJwtValidator.verifySignature(any()) } returns true
         coEvery { mockedJwtValidator.validateDidInHeaderAndPayload(any(), any()) } returns true
 
         // Act and Assert
         runBlocking {
-            val actualLinkedDomainsResultResponse = linkedDomainsService.fetchDocumentAndVerifyLinkedDomains(suppliedDidWithSingleServiceEndpoint)
+            val actualLinkedDomainsResultResponse =
+                linkedDomainsService.fetchDocumentAndVerifyLinkedDomains(suppliedDidWithSingleServiceEndpoint)
             assertThat(actualLinkedDomainsResultResponse).isInstanceOf(KotlinResult.success(LinkedDomainVerified)::class.java)
             assertThat((actualLinkedDomainsResultResponse.getOrNull() as? LinkedDomainVerified)?.domainUrl).isEqualTo(hostnameOfUrl)
         }
@@ -163,14 +211,19 @@ class LinkedDomainsServiceTest {
             defaultTestSerializer.decodeFromString(LinkedDomainsResponse.serializer(), expectedWellKnownConfigDocumentResponse)
         val expectedDomainUrl = "https://issuertestng.com"
         val hostnameOfUrl = URI(expectedDomainUrl).host
-        coEvery { linkedDomainsService.resolveIdentifierDocument(suppliedDidWithMultipleServiceEndpoints) } returns KotlinResult.success(expectedResponse.didDocument)
-        coEvery { linkedDomainsService["getWellKnownConfigDocument"](expectedDomainUrl) } returns KotlinResult.success(expectedWellKnownConfigDocument)
+        coEvery { linkedDomainsService.resolveIdentifierDocument(suppliedDidWithMultipleServiceEndpoints) } returns KotlinResult.success(
+            expectedResponse.didDocument
+        )
+        coEvery { linkedDomainsService["getWellKnownConfigDocument"](expectedDomainUrl) } returns KotlinResult.success(
+            expectedWellKnownConfigDocument
+        )
         coEvery { mockedJwtValidator.verifySignature(any()) } returns true
         coEvery { mockedJwtValidator.validateDidInHeaderAndPayload(any(), any()) } returns true
 
         // Act and Assert
         runBlocking {
-            val actualLinkedDomainsResultResponse = linkedDomainsService.fetchDocumentAndVerifyLinkedDomains(suppliedDidWithMultipleServiceEndpoints)
+            val actualLinkedDomainsResultResponse =
+                linkedDomainsService.fetchDocumentAndVerifyLinkedDomains(suppliedDidWithMultipleServiceEndpoints)
             assertThat(actualLinkedDomainsResultResponse).isInstanceOf(KotlinResult.success(LinkedDomainVerified)::class.java)
             assertThat((actualLinkedDomainsResultResponse.getOrNull() as? LinkedDomainVerified)?.domainUrl).isEqualTo(hostnameOfUrl)
         }
@@ -253,7 +306,14 @@ class LinkedDomainsServiceTest {
         val suppliedDidWithSingleServiceEndpoint =
             "did:ion:EiA8HR28m5KUig9elPRXkmKvvBGXcOoxpUrCscTdGJcIXQ?-ion-initial-state=eyJkZWx0YV9oYXNoIjoiRWlDVDV5MG5nNTJCNzVjYWFqWU9qVjBRMmpxSng0NDZSajhRTjFpaHdteUpJZyIsInJlY292ZXJ5X2NvbW1pdG1lbnQiOiJFaURsOER4eXZLa3lvRmJsUWp0OXllU2J3TXkwR083MFM1R2FUU1F0UlF0aFJRIn0.eyJ1cGRhdGVfY29tbWl0bWVudCI6IkVpRGFXS2sycjJiSWJsRWFpRUhtRU5Kc2h6czhtY1hJd2hTV0Z1YmtWQlJ3WWciLCJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljX2tleXMiOlt7ImlkIjoic2lnX2VkMmM1ZWRmIiwidHlwZSI6IkVjZHNhU2VjcDI1NmsxVmVyaWZpY2F0aW9uS2V5MjAxOSIsImp3ayI6eyJrdHkiOiJFQyIsImNydiI6InNlY3AyNTZrMSIsIngiOiJoTzhYaXhtWUxNOVVVMmFWOW9kc2VsSDNobDJtbVFPLS1GTzNKa2JrekVrIiwieSI6InBDWEpxbXpUbzVQQkdRTERibnRtdUFaSElZQnFZOG1DZVdkaWhpb0tGUmMifSwicHVycG9zZSI6WyJhdXRoIiwiZ2VuZXJhbCJdfV19fV19"
         val linkedDomainsService: LinkedDomainsService =
-            spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, mockRootOfTrustResolver))
+            spyk(
+                LinkedDomainsService(
+                    mockk(relaxed = true),
+                    mockedResolver,
+                    mockedJwtDomainLinkageCredentialValidator,
+                    mockRootOfTrustResolver
+                )
+            )
         val didMetadata = DidMetadata()
         didMetadata.id = suppliedDidWithSingleServiceEndpoint
         val rpDidDoc =
@@ -267,7 +327,8 @@ class LinkedDomainsServiceTest {
 
         // Act and Assert
         runBlocking {
-            val actualLinkedDomainsResultResponse = linkedDomainsService.fetchDocumentAndVerifyLinkedDomains(suppliedDidWithSingleServiceEndpoint)
+            val actualLinkedDomainsResultResponse =
+                linkedDomainsService.fetchDocumentAndVerifyLinkedDomains(suppliedDidWithSingleServiceEndpoint)
             assertThat(actualLinkedDomainsResultResponse).isInstanceOf(KotlinResult.success(LinkedDomainVerified)::class.java)
             assertThat((actualLinkedDomainsResultResponse.getOrNull() as? LinkedDomainVerified)?.domainUrl).isEqualTo("discover.did.microsoft.com")
         }
@@ -282,7 +343,14 @@ class LinkedDomainsServiceTest {
         val suppliedDidWithSingleServiceEndpoint =
             "did:ion:EiA8HR28m5KUig9elPRXkmKvvBGXcOoxpUrCscTdGJcIXQ?-ion-initial-state=eyJkZWx0YV9oYXNoIjoiRWlDVDV5MG5nNTJCNzVjYWFqWU9qVjBRMmpxSng0NDZSajhRTjFpaHdteUpJZyIsInJlY292ZXJ5X2NvbW1pdG1lbnQiOiJFaURsOER4eXZLa3lvRmJsUWp0OXllU2J3TXkwR083MFM1R2FUU1F0UlF0aFJRIn0.eyJ1cGRhdGVfY29tbWl0bWVudCI6IkVpRGFXS2sycjJiSWJsRWFpRUhtRU5Kc2h6czhtY1hJd2hTV0Z1YmtWQlJ3WWciLCJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljX2tleXMiOlt7ImlkIjoic2lnX2VkMmM1ZWRmIiwidHlwZSI6IkVjZHNhU2VjcDI1NmsxVmVyaWZpY2F0aW9uS2V5MjAxOSIsImp3ayI6eyJrdHkiOiJFQyIsImNydiI6InNlY3AyNTZrMSIsIngiOiJoTzhYaXhtWUxNOVVVMmFWOW9kc2VsSDNobDJtbVFPLS1GTzNKa2JrekVrIiwieSI6InBDWEpxbXpUbzVQQkdRTERibnRtdUFaSElZQnFZOG1DZVdkaWhpb0tGUmMifSwicHVycG9zZSI6WyJhdXRoIiwiZ2VuZXJhbCJdfV19fV19"
         val linkedDomainsService: LinkedDomainsService =
-            spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, mockRootOfTrustResolver))
+            spyk(
+                LinkedDomainsService(
+                    mockk(relaxed = true),
+                    mockedResolver,
+                    mockedJwtDomainLinkageCredentialValidator,
+                    mockRootOfTrustResolver
+                )
+            )
         val didMetadata = DidMetadata()
         didMetadata.id = suppliedDidWithSingleServiceEndpoint
         val expectedResponseString =
@@ -294,14 +362,19 @@ class LinkedDomainsServiceTest {
             defaultTestSerializer.decodeFromString(LinkedDomainsResponse.serializer(), expectedWellKnownConfigDocumentResponse)
         val expectedDomainUrl = "https://discover.did.microsoft.com"
         val hostnameOfUrl = URI(expectedDomainUrl).host
-        coEvery { linkedDomainsService.resolveIdentifierDocument(suppliedDidWithSingleServiceEndpoint) } returns KotlinResult.success(expectedResponse.didDocument)
-        coEvery { linkedDomainsService["getWellKnownConfigDocument"](expectedDomainUrl) } returns KotlinResult.success(expectedWellKnownConfigDocument)
+        coEvery { linkedDomainsService.resolveIdentifierDocument(suppliedDidWithSingleServiceEndpoint) } returns KotlinResult.success(
+            expectedResponse.didDocument
+        )
+        coEvery { linkedDomainsService["getWellKnownConfigDocument"](expectedDomainUrl) } returns KotlinResult.success(
+            expectedWellKnownConfigDocument
+        )
         coEvery { mockedJwtValidator.verifySignature(any()) } returns true
         coEvery { mockedJwtValidator.validateDidInHeaderAndPayload(any(), any()) } returns true
 
         // Act and Assert
         runBlocking {
-            val actualLinkedDomainsResultResponse = linkedDomainsService.fetchDocumentAndVerifyLinkedDomains(suppliedDidWithSingleServiceEndpoint)
+            val actualLinkedDomainsResultResponse =
+                linkedDomainsService.fetchDocumentAndVerifyLinkedDomains(suppliedDidWithSingleServiceEndpoint)
             assertThat(actualLinkedDomainsResultResponse).isInstanceOf(KotlinResult.success(LinkedDomainVerified)::class.java)
             assertThat((actualLinkedDomainsResultResponse.getOrNull() as? LinkedDomainVerified)?.domainUrl).isEqualTo(hostnameOfUrl)
         }

--- a/walletlibrary/src/test/java/com/microsoft/walletlibrary/did/sdk/MockInjectedRootOfTrustResolver.kt
+++ b/walletlibrary/src/test/java/com/microsoft/walletlibrary/did/sdk/MockInjectedRootOfTrustResolver.kt
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved
+
+package com.microsoft.walletlibrary.did.sdk
+
+import com.microsoft.walletlibrary.did.sdk.identifier.models.identifierdocument.DidMetadata
+import com.microsoft.walletlibrary.did.sdk.identifier.resolvers.RootOfTrustResolver
+import com.microsoft.walletlibrary.requests.RootOfTrust
+
+class MockInjectedRootOfTrustResolver : RootOfTrustResolver {
+    override suspend fun resolve(didMetadata: DidMetadata): RootOfTrust {
+        when (didMetadata.id) {
+            MockDidMetadata.VALID_DOMAIN_DID.value -> {
+                return RootOfTrust("validDomain", true)
+            }
+            MockDidMetadata.EMPTY_DOMAIN_DID.value -> {
+                throw EmptyDomainListException()
+            }
+            else -> {
+                throw DomainValidationException()
+            }
+        }
+    }
+}
+
+class EmptyDomainListException : Exception()
+
+class DomainValidationException : Exception()
+
+enum class MockDidMetadata(val value: String) {
+    VALID_DOMAIN_DID("did:web:validDomain"),
+    EMPTY_DOMAIN_DID("did:web:emptyDomainList")
+}

--- a/walletlibrary/src/test/java/com/microsoft/walletlibrary/requests/handlers/SignedMetadataProcessorTest.kt
+++ b/walletlibrary/src/test/java/com/microsoft/walletlibrary/requests/handlers/SignedMetadataProcessorTest.kt
@@ -1,10 +1,16 @@
 package com.microsoft.walletlibrary.requests.handlers
 
 import com.microsoft.walletlibrary.did.sdk.LinkedDomainsService
+import com.microsoft.walletlibrary.did.sdk.MockDidMetadata
+import com.microsoft.walletlibrary.did.sdk.MockInjectedRootOfTrustResolver
 import com.microsoft.walletlibrary.did.sdk.VerifiableCredentialSdk
+import com.microsoft.walletlibrary.did.sdk.credential.service.models.linkedDomains.LinkedDomainVerified
+import com.microsoft.walletlibrary.did.sdk.credential.service.validators.JwtDomainLinkageCredentialValidator
+import com.microsoft.walletlibrary.did.sdk.credential.service.validators.JwtValidator
 import com.microsoft.walletlibrary.did.sdk.crypto.protocols.jose.jws.JwsToken
+import com.microsoft.walletlibrary.did.sdk.identifier.models.identifierdocument.DidMetadata
 import com.microsoft.walletlibrary.did.sdk.identifier.models.identifierdocument.IdentifierDocument
-import com.microsoft.walletlibrary.did.sdk.identifier.resolvers.MockRootOfTrustResolver
+import com.microsoft.walletlibrary.did.sdk.identifier.resolvers.Resolver
 import com.microsoft.walletlibrary.mappings.getJwk
 import com.microsoft.walletlibrary.networking.entities.openid4vci.credentialmetadata.SignedMetadataTokenClaims
 import com.microsoft.walletlibrary.requests.RootOfTrust
@@ -18,10 +24,13 @@ import com.microsoft.walletlibrary.wrapper.IdentifierDocumentResolver
 import com.microsoft.walletlibrary.wrapper.LinkedDomainsResolver
 import com.nimbusds.jose.jwk.JWK
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.spyk
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.SerializationException
 import org.assertj.core.api.Assertions.assertThat
@@ -35,7 +44,7 @@ class SignedMetadataProcessorTest {
     private val mockIdentifierDocument = mockk<IdentifierDocument>()
     private val mockJwsToken: JwsToken = mockk()
     private val mockJwk = mockk<JWK>()
-    private val mockLinedDomainsService: LinkedDomainsService = mockk()
+    private val mockLinkedDomainsService: LinkedDomainsService = mockk()
 
     init {
         mockkStatic(VerifiableCredentialSdk::class)
@@ -43,7 +52,7 @@ class SignedMetadataProcessorTest {
         mockkStatic(LinkedDomainsResolver::class)
         mockkStatic("com.microsoft.walletlibrary.mappings.IdentifierDocumentMappingKt")
         mockkStatic("com.microsoft.walletlibrary.mappings.LinkedDomainMappingKt")
-        every { VerifiableCredentialSdk.linkedDomainsService } returns mockLinedDomainsService
+        every { VerifiableCredentialSdk.linkedDomainsService } returns mockLinkedDomainsService
         every { mockLibraryConfiguration.serializer } returns defaultTestSerializer
         every { signedMetadataProcessor["deserializeSignedMetadata"](signedMetadataString) } returns mockJwsToken
     }
@@ -235,54 +244,100 @@ class SignedMetadataProcessorTest {
     }
 
     @Test
-    fun process_LinkedDomainsNotVerifiedByResolver_ReturnsUnverifiedRootOfTrust() {
+    fun process_LinkedDomainsVerifiedByResolver_ReturnsVerifiedRootOfTrust() {
         // Arrange
-        every { mockLibraryConfiguration.rootOfTrustResolver } returns MockRootOfTrustResolver(false)
         mockIdentifierDocument()
+        mockkStatic(VerifiableCredentialSdk::class)
+        mockkObject(LinkedDomainsResolver)
+        val mockedResolver: Resolver = mockk()
+        val mockedJwtValidator: JwtValidator = mockk()
+        val mockRootOfTrustResolver = spyk(MockInjectedRootOfTrustResolver(), recordPrivateCalls = true)
+        val mockedJwtDomainLinkageCredentialValidator = JwtDomainLinkageCredentialValidator(mockedJwtValidator, com.microsoft.walletlibrary.did.sdk.di.defaultTestSerializer)
+        val linkedDomainsService = LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, mockRootOfTrustResolver)
+        every { VerifiableCredentialSdk.linkedDomainsService } answers { linkedDomainsService }
+        every { LinkedDomainsResolver["getLinkedDomainsService"]() } answers { linkedDomainsService }
         val signedMetadataTokenClaimsString =
-            """{"sub":"testCredentialIssuer","iss": "did:web:test","iat": 1707859806}""".trimIndent()
-        mockJwsToken("did:web:test#signingKey-1", signedMetadataTokenClaimsString)
-        coEvery { IdentifierDocumentResolver.resolveIdentifierDocument("did:web:test") } returns mockIdentifierDocument
-        coEvery { LinkedDomainsResolver.resolve(mockIdentifierDocument) } returns RootOfTrust(
-            "discover.did.microsoft.com",
-            false
-        )
+            """{"sub":"testCredentialIssuer","iss": "${MockDidMetadata.VALID_DOMAIN_DID.value}","iat": 1707859806}""".trimIndent()
+        mockJwsToken("${MockDidMetadata.VALID_DOMAIN_DID.value}#signingKey-1", signedMetadataTokenClaimsString)
+        coEvery { IdentifierDocumentResolver.resolveIdentifierDocument(MockDidMetadata.VALID_DOMAIN_DID.value) } returns mockIdentifierDocument
+        every { (mockIdentifierDocument as DidMetadata).id } returns MockDidMetadata.VALID_DOMAIN_DID.value
 
         runBlocking {
             // Act
-            val actualResult =
-                signedMetadataProcessor.process(signedMetadataString, credentialIssuer)
+            val actualResult = signedMetadataProcessor.process(signedMetadataString, credentialIssuer)
 
             // Assert
             assertThat(actualResult).isInstanceOf(RootOfTrust::class.java)
-            assertThat(actualResult.source).isEqualTo("discover.did.microsoft.com")
-            assertThat(actualResult.verified).isFalse
+            assertThat(actualResult.source).isEqualTo("validDomain")
+            assertThat(actualResult.verified).isTrue
+            coVerify { mockRootOfTrustResolver.resolve(any<DidMetadata>()) }
         }
     }
 
     @Test
-    fun process_LinkedDomainsVerifiedByResolver_ReturnsVerifiedRootOfTrust() {
+    fun process_LinkedDomainsNotVerifiedByResolverUsingWellKnownAndPasses_ReturnsVerifiedRootOfTrust() {
         // Arrange
-        every { mockLibraryConfiguration.rootOfTrustResolver } returns MockRootOfTrustResolver(true)
         mockIdentifierDocument()
+        mockkStatic(VerifiableCredentialSdk::class)
+        mockkObject(LinkedDomainsResolver)
+        val mockedResolver: Resolver = mockk()
+        val mockedJwtValidator: JwtValidator = mockk()
+        val mockRootOfTrustResolver = spyk(MockInjectedRootOfTrustResolver(), recordPrivateCalls = true)
+        val mockedJwtDomainLinkageCredentialValidator = JwtDomainLinkageCredentialValidator(mockedJwtValidator, com.microsoft.walletlibrary.did.sdk.di.defaultTestSerializer)
+        val linkedDomainsService = spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, mockRootOfTrustResolver), recordPrivateCalls = true)
+        every { VerifiableCredentialSdk.linkedDomainsService } answers { linkedDomainsService }
+        every { LinkedDomainsResolver["getLinkedDomainsService"]() } answers { linkedDomainsService }
         val signedMetadataTokenClaimsString =
-            """{"sub":"testCredentialIssuer","iss": "did:web:test","iat": 1707859806}""".trimIndent()
-        mockJwsToken("did:web:test#signingKey-1", signedMetadataTokenClaimsString)
-        coEvery { IdentifierDocumentResolver.resolveIdentifierDocument("did:web:test") } returns mockIdentifierDocument
-        coEvery { LinkedDomainsResolver.resolve(mockIdentifierDocument) } returns RootOfTrust(
-            "discover.did.microsoft.com",
-            true
+            """{"sub":"testCredentialIssuer","iss": "${MockDidMetadata.VALID_DOMAIN_DID.value}","iat": 1707859806}""".trimIndent()
+        mockJwsToken("${MockDidMetadata.VALID_DOMAIN_DID.value}#signingKey-1", signedMetadataTokenClaimsString)
+        coEvery { IdentifierDocumentResolver.resolveIdentifierDocument(MockDidMetadata.VALID_DOMAIN_DID.value) } returns mockIdentifierDocument
+        every { (mockIdentifierDocument as DidMetadata).id } returns MockDidMetadata.EMPTY_DOMAIN_DID.value
+        coEvery { linkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) } returns LinkedDomainVerified(
+            "testdomain"
         )
 
         runBlocking {
             // Act
-            val actualResult =
-                signedMetadataProcessor.process(signedMetadataString, credentialIssuer)
+            val actualResult = signedMetadataProcessor.process(signedMetadataString, credentialIssuer)
 
             // Assert
             assertThat(actualResult).isInstanceOf(RootOfTrust::class.java)
-            assertThat(actualResult.source).isEqualTo("discover.did.microsoft.com")
+            assertThat(actualResult.source).isEqualTo("testdomain")
             assertThat(actualResult.verified).isTrue
+            coVerify { mockRootOfTrustResolver.resolve(any<DidMetadata>()) }
+            verify { linkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](any<IdentifierDocument>()) }
+        }
+    }
+
+    @Test
+    fun process_LinkedDomainsNotVerifiedByResolverUsingWellKnownAndFails_ReturnsMissingRootOfTrust() {
+        // Arrange
+        mockIdentifierDocument()
+        mockkStatic(VerifiableCredentialSdk::class)
+        mockkObject(LinkedDomainsResolver)
+        val mockedResolver: Resolver = mockk()
+        val mockedJwtValidator: JwtValidator = mockk()
+        val mockRootOfTrustResolver = spyk(MockInjectedRootOfTrustResolver(), recordPrivateCalls = true)
+        val mockedJwtDomainLinkageCredentialValidator = JwtDomainLinkageCredentialValidator(mockedJwtValidator, com.microsoft.walletlibrary.did.sdk.di.defaultTestSerializer)
+        val linkedDomainsService = spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, mockRootOfTrustResolver), recordPrivateCalls = true)
+        every { VerifiableCredentialSdk.linkedDomainsService } answers { linkedDomainsService }
+        every { LinkedDomainsResolver["getLinkedDomainsService"]() } answers { linkedDomainsService }
+        val signedMetadataTokenClaimsString =
+            """{"sub":"testCredentialIssuer","iss": "${MockDidMetadata.VALID_DOMAIN_DID.value}","iat": 1707859806}""".trimIndent()
+        mockJwsToken("${MockDidMetadata.VALID_DOMAIN_DID.value}#signingKey-1", signedMetadataTokenClaimsString)
+        coEvery { IdentifierDocumentResolver.resolveIdentifierDocument(MockDidMetadata.VALID_DOMAIN_DID.value) } returns mockIdentifierDocument
+        every { (mockIdentifierDocument as DidMetadata).id } returns MockDidMetadata.EMPTY_DOMAIN_DID.value
+
+        runBlocking {
+            // Act
+            val actualResult = signedMetadataProcessor.process(signedMetadataString, credentialIssuer)
+
+            // Assert
+            assertThat(actualResult).isInstanceOf(RootOfTrust::class.java)
+            assertThat(actualResult.source).isEqualTo("")
+            assertThat(actualResult.verified).isFalse
+            coVerify { mockRootOfTrustResolver.resolve(any<DidMetadata>()) }
+            verify { linkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](any<IdentifierDocument>()) }
         }
     }
 

--- a/walletlibrary/src/test/java/com/microsoft/walletlibrary/requests/handlers/SignedMetadataProcessorTest.kt
+++ b/walletlibrary/src/test/java/com/microsoft/walletlibrary/requests/handlers/SignedMetadataProcessorTest.kt
@@ -252,8 +252,10 @@ class SignedMetadataProcessorTest {
         val mockedResolver: Resolver = mockk()
         val mockedJwtValidator: JwtValidator = mockk()
         val mockRootOfTrustResolver = spyk(MockInjectedRootOfTrustResolver(), recordPrivateCalls = true)
-        val mockedJwtDomainLinkageCredentialValidator = JwtDomainLinkageCredentialValidator(mockedJwtValidator, com.microsoft.walletlibrary.did.sdk.di.defaultTestSerializer)
-        val linkedDomainsService = LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, mockRootOfTrustResolver)
+        val mockedJwtDomainLinkageCredentialValidator =
+            JwtDomainLinkageCredentialValidator(mockedJwtValidator, com.microsoft.walletlibrary.did.sdk.di.defaultTestSerializer)
+        val linkedDomainsService =
+            LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, mockRootOfTrustResolver)
         every { VerifiableCredentialSdk.linkedDomainsService } answers { linkedDomainsService }
         every { LinkedDomainsResolver["getLinkedDomainsService"]() } answers { linkedDomainsService }
         val signedMetadataTokenClaimsString =
@@ -283,8 +285,16 @@ class SignedMetadataProcessorTest {
         val mockedResolver: Resolver = mockk()
         val mockedJwtValidator: JwtValidator = mockk()
         val mockRootOfTrustResolver = spyk(MockInjectedRootOfTrustResolver(), recordPrivateCalls = true)
-        val mockedJwtDomainLinkageCredentialValidator = JwtDomainLinkageCredentialValidator(mockedJwtValidator, com.microsoft.walletlibrary.did.sdk.di.defaultTestSerializer)
-        val linkedDomainsService = spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, mockRootOfTrustResolver), recordPrivateCalls = true)
+        val mockedJwtDomainLinkageCredentialValidator =
+            JwtDomainLinkageCredentialValidator(mockedJwtValidator, com.microsoft.walletlibrary.did.sdk.di.defaultTestSerializer)
+        val linkedDomainsService = spyk(
+            LinkedDomainsService(
+                mockk(relaxed = true),
+                mockedResolver,
+                mockedJwtDomainLinkageCredentialValidator,
+                mockRootOfTrustResolver
+            ), recordPrivateCalls = true
+        )
         every { VerifiableCredentialSdk.linkedDomainsService } answers { linkedDomainsService }
         every { LinkedDomainsResolver["getLinkedDomainsService"]() } answers { linkedDomainsService }
         val signedMetadataTokenClaimsString =
@@ -318,8 +328,16 @@ class SignedMetadataProcessorTest {
         val mockedResolver: Resolver = mockk()
         val mockedJwtValidator: JwtValidator = mockk()
         val mockRootOfTrustResolver = spyk(MockInjectedRootOfTrustResolver(), recordPrivateCalls = true)
-        val mockedJwtDomainLinkageCredentialValidator = JwtDomainLinkageCredentialValidator(mockedJwtValidator, com.microsoft.walletlibrary.did.sdk.di.defaultTestSerializer)
-        val linkedDomainsService = spyk(LinkedDomainsService(mockk(relaxed = true), mockedResolver, mockedJwtDomainLinkageCredentialValidator, mockRootOfTrustResolver), recordPrivateCalls = true)
+        val mockedJwtDomainLinkageCredentialValidator =
+            JwtDomainLinkageCredentialValidator(mockedJwtValidator, com.microsoft.walletlibrary.did.sdk.di.defaultTestSerializer)
+        val linkedDomainsService = spyk(
+            LinkedDomainsService(
+                mockk(relaxed = true),
+                mockedResolver,
+                mockedJwtDomainLinkageCredentialValidator,
+                mockRootOfTrustResolver
+            ), recordPrivateCalls = true
+        )
         every { VerifiableCredentialSdk.linkedDomainsService } answers { linkedDomainsService }
         every { LinkedDomainsResolver["getLinkedDomainsService"]() } answers { linkedDomainsService }
         val signedMetadataTokenClaimsString =

--- a/walletlibrary/src/test/java/com/microsoft/walletlibrary/wrapper/LinkedDomainsResolverTest.kt
+++ b/walletlibrary/src/test/java/com/microsoft/walletlibrary/wrapper/LinkedDomainsResolverTest.kt
@@ -1,34 +1,46 @@
 package com.microsoft.walletlibrary.wrapper
 
 import com.microsoft.walletlibrary.did.sdk.LinkedDomainsService
+import com.microsoft.walletlibrary.did.sdk.MockDidMetadata
+import com.microsoft.walletlibrary.did.sdk.MockInjectedRootOfTrustResolver
 import com.microsoft.walletlibrary.did.sdk.VerifiableCredentialSdk
 import com.microsoft.walletlibrary.did.sdk.credential.service.models.linkedDomains.LinkedDomainVerified
+import com.microsoft.walletlibrary.did.sdk.credential.service.validators.JwtDomainLinkageCredentialValidator
+import com.microsoft.walletlibrary.did.sdk.credential.service.validators.JwtValidator
+import com.microsoft.walletlibrary.did.sdk.di.defaultTestSerializer
 import com.microsoft.walletlibrary.did.sdk.identifier.models.identifierdocument.IdentifierDocument
+import com.microsoft.walletlibrary.did.sdk.identifier.resolvers.Resolver
 import com.microsoft.walletlibrary.did.sdk.util.controlflow.SdkException
 import com.microsoft.walletlibrary.requests.RootOfTrust
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.spyk
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import org.junit.Test
 import kotlin.Result as KotlinResult
 
 class LinkedDomainsResolverTest {
-    private val mockLinedDomainsService: LinkedDomainsService = mockk()
+    private val mockLinkedDomainsService: LinkedDomainsService = mockk()
     private val mockIdentifierDocument: IdentifierDocument = mockk()
     private val expectedDomain = "testdomain"
 
     init {
         mockkStatic(VerifiableCredentialSdk::class)
-        every { VerifiableCredentialSdk.linkedDomainsService } returns mockLinedDomainsService
+        every { VerifiableCredentialSdk.linkedDomainsService } returns mockLinkedDomainsService
     }
 
     @Test
     fun resolveRootOfTrust_VerifiedLinkedDomainExists_ReturnsRootOfTrustWithVerifiedDomain() {
         // Arrange
-        coEvery { mockLinedDomainsService.validateLinkedDomains(mockIdentifierDocument) } returns KotlinResult.success(LinkedDomainVerified(expectedDomain))
+        coEvery { mockLinkedDomainsService.validateLinkedDomains(mockIdentifierDocument) } returns KotlinResult.success(
+            LinkedDomainVerified(
+                expectedDomain
+            )
+        )
 
         runBlocking {
             // Act
@@ -44,7 +56,7 @@ class LinkedDomainsResolverTest {
     @Test
     fun resolveRootOfTrust_FailedWhileFetchingOrVerifying_ReturnsRootOfTrustWithUnverifiedEmptyDomain() {
         // Arrange
-        coEvery { mockLinedDomainsService.validateLinkedDomains(mockIdentifierDocument) } returns KotlinResult.failure(SdkException())
+        coEvery { mockLinkedDomainsService.validateLinkedDomains(mockIdentifierDocument) } returns KotlinResult.failure(SdkException())
 
         runBlocking {
             // Act
@@ -55,5 +67,128 @@ class LinkedDomainsResolverTest {
             Assertions.assertThat(actualResult.verified).isFalse
             Assertions.assertThat(actualResult.source).isEqualTo("")
         }
+    }
+
+    @Test
+    fun resolveRootOfTrustWithInjectedResolver_VerifiedLinkedDomainExists_ReturnsRootOfTrustWithVerifiedDomain() {
+        // Arrange
+        val mockedResolver: Resolver = mockk()
+        val mockedJwtValidator: JwtValidator = mockk()
+        val mockedJwtDomainLinkageCredentialValidator = JwtDomainLinkageCredentialValidator(mockedJwtValidator, defaultTestSerializer)
+        val mockLinkedDomainsService: LinkedDomainsService =
+            spyk(
+                LinkedDomainsService(
+                    mockk(relaxed = true),
+                    mockedResolver,
+                    mockedJwtDomainLinkageCredentialValidator,
+                    MockInjectedRootOfTrustResolver()
+                ), recordPrivateCalls = true
+            )
+        every { VerifiableCredentialSdk.linkedDomainsService } returns mockLinkedDomainsService
+        val mockIdentifierDocument = IdentifierDocument(id = MockDidMetadata.VALID_DOMAIN_DID.value)
+
+        runBlocking {
+            // Act
+            val actualResult = LinkedDomainsResolver.resolve(mockIdentifierDocument)
+
+            // Assert
+            Assertions.assertThat(actualResult).isInstanceOf(RootOfTrust::class.java)
+            Assertions.assertThat(actualResult.verified).isTrue
+            Assertions.assertThat(actualResult.source).isEqualTo("validDomain")
+        }
+    }
+
+    @Test
+    fun resolveRootOfTrustWithInjectedResolver_LinkedDomainDoesNotExist_ReturnsRootOfTrustWithMissingDomainFromWellKnown() {
+        // Arrange
+        val mockedResolver: Resolver = mockk()
+        val mockedJwtValidator: JwtValidator = mockk()
+        val mockedJwtDomainLinkageCredentialValidator = JwtDomainLinkageCredentialValidator(mockedJwtValidator, defaultTestSerializer)
+        val mockLinkedDomainsService: LinkedDomainsService =
+            spyk(
+                LinkedDomainsService(
+                    mockk(relaxed = true),
+                    mockedResolver,
+                    mockedJwtDomainLinkageCredentialValidator,
+                    MockInjectedRootOfTrustResolver()
+                ), recordPrivateCalls = true
+            )
+        every { VerifiableCredentialSdk.linkedDomainsService } returns mockLinkedDomainsService
+        val mockIdentifierDocument = IdentifierDocument(id = MockDidMetadata.EMPTY_DOMAIN_DID.value)
+
+        runBlocking {
+            // Act
+            val actualResult = LinkedDomainsResolver.resolve(mockIdentifierDocument)
+
+            // Assert
+            Assertions.assertThat(actualResult).isInstanceOf(RootOfTrust::class.java)
+            Assertions.assertThat(actualResult.verified).isFalse
+            Assertions.assertThat(actualResult.source).isEqualTo("")
+        }
+        coVerify { mockLinkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) }
+    }
+
+    @Test
+    fun resolveRootOfTrustWithInjectedResolver_FailsUsesWellKnown_ReturnsRootOfTrustWithValidDomain() {
+        // Arrange
+        val mockedResolver: Resolver = mockk()
+        val mockedJwtValidator: JwtValidator = mockk()
+        val mockedJwtDomainLinkageCredentialValidator = JwtDomainLinkageCredentialValidator(mockedJwtValidator, defaultTestSerializer)
+        val mockLinkedDomainsService: LinkedDomainsService =
+            spyk(
+                LinkedDomainsService(
+                    mockk(relaxed = true),
+                    mockedResolver,
+                    mockedJwtDomainLinkageCredentialValidator,
+                    MockInjectedRootOfTrustResolver()
+                ), recordPrivateCalls = true
+            )
+        every { VerifiableCredentialSdk.linkedDomainsService } returns mockLinkedDomainsService
+        val mockIdentifierDocument = IdentifierDocument(id = "failure")
+        coEvery { mockLinkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) } returns LinkedDomainVerified(
+            "testdomain"
+        )
+
+        runBlocking {
+            // Act
+            val actualResult = LinkedDomainsResolver.resolve(mockIdentifierDocument)
+
+            // Assert
+            Assertions.assertThat(actualResult).isInstanceOf(RootOfTrust::class.java)
+            Assertions.assertThat(actualResult.verified).isTrue
+            Assertions.assertThat(actualResult.source).isEqualTo("testdomain")
+        }
+        coVerify { mockLinkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) }
+    }
+
+    @Test
+    fun resolveRootOfTrustWithInjectedResolver_FailsUsesWellKnownAndAlsoFails_ReturnsRootOfTrustWithMissingDomain() {
+        // Arrange
+        val mockedResolver: Resolver = mockk()
+        val mockedJwtValidator: JwtValidator = mockk()
+        val mockedJwtDomainLinkageCredentialValidator = JwtDomainLinkageCredentialValidator(mockedJwtValidator, defaultTestSerializer)
+        val mockLinkedDomainsService: LinkedDomainsService =
+            spyk(
+                LinkedDomainsService(
+                    mockk(relaxed = true),
+                    mockedResolver,
+                    mockedJwtDomainLinkageCredentialValidator,
+                    MockInjectedRootOfTrustResolver()
+                ), recordPrivateCalls = true
+            )
+        every { VerifiableCredentialSdk.linkedDomainsService } returns mockLinkedDomainsService
+        val mockIdentifierDocument = IdentifierDocument(id = "failure")
+        coEvery { mockLinkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) } throws Exception()
+
+        runBlocking {
+            // Act
+            val actualResult = LinkedDomainsResolver.resolve(mockIdentifierDocument)
+
+            // Assert
+            Assertions.assertThat(actualResult).isInstanceOf(RootOfTrust::class.java)
+            Assertions.assertThat(actualResult.verified).isFalse
+            Assertions.assertThat(actualResult.source).isEqualTo("")
+        }
+        coVerify { mockLinkedDomainsService["verifyLinkedDomainsUsingWellKnownDocument"](mockIdentifierDocument) }
     }
 }


### PR DESCRIPTION
- If injected root of trust resolver fails validating the linked domains, fallback option must be used. It is handled by the wrapper using which prevents duplicating the code. 
- This PR also includes unit tests for all the combinations of resolver and fallback option that need to be tested.


**Validation:**
Added unit tests for all the combinations of resolver and fallback option that need to be tested.


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.