### PR TITLE
Adding a method to get additional metadata about a credential

### DIFF
--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/verifiedid/OpenId4VciVerifiedId.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/verifiedid/OpenId4VciVerifiedId.kt
@@ -45,8 +45,10 @@ internal class OpenId4VciVerifiedId(
         return claims
     }
 
-    override fun isHolder(identity: HolderIdentifier): Boolean {
-        return raw.contents.sub == identity.id
+    override fun getMetadata(): VerifiedIdMetadata {
+        return VerifiedIdMetadata(
+            holderID = raw.contents.sub
+        )
     }
 
     private fun createVerifiedIdClaim(claimReference: String, claimValue: Any): VerifiedIdClaim {

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/verifiedid/OpenId4VciVerifiedId.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/verifiedid/OpenId4VciVerifiedId.kt
@@ -3,6 +3,7 @@
 package com.microsoft.walletlibrary.verifiedid
 
 import com.microsoft.walletlibrary.did.sdk.credential.models.VerifiableCredential
+import com.microsoft.walletlibrary.identifier.HolderIdentifier
 import com.microsoft.walletlibrary.networking.entities.openid4vci.credentialmetadata.CredentialConfiguration
 import kotlinx.serialization.Serializable
 import java.util.Date
@@ -42,6 +43,10 @@ internal class OpenId4VciVerifiedId(
             claims.add(createVerifiedIdClaim(claimIdentifier, claimValue))
         }
         return claims
+    }
+
+    override fun isHolder(identity: HolderIdentifier): Boolean {
+        return raw.contents.sub == identity.id
     }
 
     private fun createVerifiedIdClaim(claimReference: String, claimValue: Any): VerifiedIdClaim {

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/verifiedid/VerifiableCredential.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/verifiedid/VerifiableCredential.kt
@@ -2,6 +2,7 @@ package com.microsoft.walletlibrary.verifiedid
 
 import com.microsoft.walletlibrary.did.sdk.credential.models.VerifiableCredential
 import com.microsoft.walletlibrary.did.sdk.credential.service.models.contracts.VerifiableCredentialContract
+import com.microsoft.walletlibrary.identifier.HolderIdentifier
 import com.microsoft.walletlibrary.mappings.issuance.toVerifiedIdStyle
 import com.microsoft.walletlibrary.requests.styles.NoneVerifiedIdStyle
 import kotlinx.serialization.Serializable
@@ -38,5 +39,9 @@ internal class VerifiableCredential(
                 ?: claims.add(VerifiedIdClaim(claimIdentifier, claimValue, null, null))
         }
         return claims
+    }
+
+    override fun isHolder(identity: HolderIdentifier): Boolean {
+        return raw.contents.sub == identity.id
     }
 }

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/verifiedid/VerifiableCredential.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/verifiedid/VerifiableCredential.kt
@@ -41,7 +41,9 @@ internal class VerifiableCredential(
         return claims
     }
 
-    override fun isHolder(identity: HolderIdentifier): Boolean {
-        return raw.contents.sub == identity.id
+    override fun getMetadata(): VerifiedIdMetadata {
+        return VerifiedIdMetadata(
+            holderID = raw.contents.sub
+        )
     }
 }

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/verifiedid/VerifiedId.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/verifiedid/VerifiedId.kt
@@ -30,6 +30,6 @@ interface VerifiedId {
     // Return list of claims in the Verified ID.
     fun getClaims(): ArrayList<VerifiedIdClaim>
 
-    // True iff identity is the holder of this credential
-    fun isHolder(identity: HolderIdentifier): Boolean
+    // Gets metadata associated with this credential
+    fun getMetadata(): VerifiedIdMetadata
 }

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/verifiedid/VerifiedId.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/verifiedid/VerifiedId.kt
@@ -5,6 +5,7 @@
 
 package com.microsoft.walletlibrary.verifiedid
 
+import com.microsoft.walletlibrary.identifier.HolderIdentifier
 import com.microsoft.walletlibrary.requests.styles.VerifiedIdStyle
 import java.util.Date
 
@@ -28,4 +29,7 @@ interface VerifiedId {
 
     // Return list of claims in the Verified ID.
     fun getClaims(): ArrayList<VerifiedIdClaim>
+
+    // True iff identity is the holder of this credential
+    fun isHolder(identity: HolderIdentifier): Boolean
 }

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/verifiedid/VerifiedIdMetadata.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/verifiedid/VerifiedIdMetadata.kt
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved
+
+package com.microsoft.walletlibrary.verifiedid
+
+/**
+ * Metadata bundle for a verified ID
+ */
+data class VerifiedIdMetadata(
+    /// HolderIdentifier's ID
+    val holderID: String? = null,
+)

--- a/walletlibrary/src/test/java/com/microsoft/walletlibrary/verifiedid/VCVerifiedIdSerializerTest.kt
+++ b/walletlibrary/src/test/java/com/microsoft/walletlibrary/verifiedid/VCVerifiedIdSerializerTest.kt
@@ -12,6 +12,7 @@ import com.microsoft.walletlibrary.did.sdk.credential.service.models.contracts.V
 import com.microsoft.walletlibrary.did.sdk.credential.service.models.contracts.display.CardDescriptor
 import com.microsoft.walletlibrary.did.sdk.credential.service.models.contracts.display.ConsentDescriptor
 import com.microsoft.walletlibrary.did.sdk.credential.service.models.contracts.display.DisplayContract
+import com.microsoft.walletlibrary.identifier.HolderIdentifier
 import com.microsoft.walletlibrary.requests.styles.NoneVerifiedIdStyle
 import com.microsoft.walletlibrary.requests.styles.VerifiedIdStyle
 import com.microsoft.walletlibrary.util.defaultTestSerializer
@@ -129,5 +130,9 @@ class MockVerifiedId : VerifiedId {
 
     override fun getClaims(): ArrayList<VerifiedIdClaim> {
         return emptyList<VerifiedIdClaim>() as ArrayList<VerifiedIdClaim>
+    }
+
+    override fun isHolder(identity: HolderIdentifier): Boolean {
+        return false
     }
 }

--- a/walletlibrary/src/test/java/com/microsoft/walletlibrary/verifiedid/VCVerifiedIdSerializerTest.kt
+++ b/walletlibrary/src/test/java/com/microsoft/walletlibrary/verifiedid/VCVerifiedIdSerializerTest.kt
@@ -132,7 +132,7 @@ class MockVerifiedId : VerifiedId {
         return emptyList<VerifiedIdClaim>() as ArrayList<VerifiedIdClaim>
     }
 
-    override fun isHolder(identity: HolderIdentifier): Boolean {
-        return false
+    override fun getMetadata(): VerifiedIdMetadata {
+        return VerifiedIdMetadata()
     }
 }


### PR DESCRIPTION
**Problem:**
Theres no way to get metadata about credentials.


**Solution:**
Adding a very general way to get metadata which can be extended over time.


**Validation:**


**Type of change:**
- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:

**Documentation Links**: