### PR TITLE
Update to telemetry and network request logging

### DIFF
--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/VerifiedIdClientBuilder.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/VerifiedIdClientBuilder.kt
@@ -111,12 +111,12 @@ class VerifiedIdClientBuilder(private val context: Context) {
 
     // Configures and returns VerifiedIdClient with the configurations provided in builder class.
     fun build(): VerifiedIdClient {
-        val vcSdkLogConsumer = WalletLibraryVCSDKLogConsumer(logger)
+        WalletLibraryVCSDKLogConsumer.logger = logger
         val userAgentInfo = getUserAgent(context)
         val walletLibraryVersionInfo = getWalletLibraryVersionInfo()
         VerifiableCredentialSdk.init(
             context,
-            logConsumer = vcSdkLogConsumer,
+            logConsumer = WalletLibraryVCSDKLogConsumer,
             userAgentInfo = userAgentInfo,
             walletLibraryVersionInfo = walletLibraryVersionInfo,
             httpAgent = httpAgent,

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/datasource/network/BaseNetworkOperation.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/datasource/network/BaseNetworkOperation.kt
@@ -34,7 +34,7 @@ internal abstract class BaseNetworkOperation<T> {
                 return onFailure(it)
             }
         } catch (exception: IOException) {
-            SdkLog.i("Failed to send request because of ${exception.message}", exception)
+            SdkLog.e("Failed to send request because of ${exception.message}", exception)
             return Result.failure(LocalNetworkException("Failed to send request because of ${exception.message}", exception))
         }
         return Result.failure(SdkException("Failed to get a response"))
@@ -44,7 +44,8 @@ internal abstract class BaseNetworkOperation<T> {
     open fun onFailure(exception: Throwable): Result<Nothing> {
         (exception as? NetworkingException)?.let {
             error ->
-            SdkLog.i("HttpError: ${error.code} body: ${error.errorBody} cv: ${error.correlationId}", exception)
+            val requestId = IResponse.getHeaderCaseInsensitive("request-id", error.headers)
+            SdkLog.e("HttpError: ${error.code} body: ${error.errorBody} cv: ${error.correlationId} request-id: $requestId", exception)
         }
         return Result.failure(exception)
     }

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/util/MeasureTime.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/util/MeasureTime.kt
@@ -32,8 +32,8 @@ internal inline fun logNetworkTime(name: String, block: () -> Result<IResponse>)
     var cvResponse = "none"
     var requestId = "none"
     val result = block().onSuccess {
-        cvResponse = it.headers[Constants.CORRELATION_VECTOR_HEADER] ?: "none"
-        requestId = it.headers[Constants.REQUEST_ID_HEADER] ?: "none"
+        cvResponse = IResponse.getHeaderCaseInsensitive(Constants.CORRELATION_VECTOR_HEADER, it.headers) ?: "none"
+        requestId = IResponse.getHeaderCaseInsensitive( Constants.REQUEST_ID_HEADER, it.headers) ?: "none"
         code = it.status
     }.onFailure {
         (it as? NetworkingException)?.let {

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/util/log/SdkLog.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/did/sdk/util/log/SdkLog.kt
@@ -24,7 +24,7 @@ internal object SdkLog {
 
     private const val ORIGINAL_CALLER_STACK_INDEX = 2
     private val ANONYMOUS_CLASS = Pattern.compile("(\\$\\d+)+$")
-    private val CONSUMERS: MutableList<Consumer> = ArrayList()
+    private val CONSUMERS: MutableSet<Consumer> = mutableSetOf()
 
     fun addConsumer(consumer: Consumer) = CONSUMERS.add(consumer)
 

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/OpenIdPresentationRequest.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/OpenIdPresentationRequest.kt
@@ -106,7 +106,8 @@ internal class OpenIdPresentationRequest(
             .onFailure {
                 throw VerifiedIdException(
                     "Failed to send presentation request. ${it.message}",
-                    VerifiedIdExceptions.REQUEST_SEND_EXCEPTION.value
+                    VerifiedIdExceptions.REQUEST_SEND_EXCEPTION.value,
+                    cause = it
                 )
             }
 

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/VerifiedIdException.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/VerifiedIdException.kt
@@ -18,7 +18,8 @@ class NetworkingException(
     val statusCode: String? = null,
     val innerError: String? = null,
     val errorBody: String? = null,
-    val retryable: Boolean = false
+    val retryable: Boolean = false,
+    val headers: Map<String, String> = emptyMap()
 ) : VerifiedIdException(message, code, correlationId)
 
 class RequirementNotMetException(

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/WalletLibraryLogger.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/WalletLibraryLogger.kt
@@ -22,7 +22,7 @@ object WalletLibraryLogger {
 
     private const val ORIGINAL_CALLER_STACK_INDEX = 2
     private val ANONYMOUS_CLASS = Pattern.compile("(\\$\\d+)+$")
-    internal val CONSUMERS: MutableList<Consumer> = ArrayList()
+    internal val CONSUMERS: MutableSet<Consumer> = mutableSetOf()
 
     fun addConsumer(consumer: Consumer) = CONSUMERS.add(consumer)
 

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/WalletLibraryVCSDKLogConsumer.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/WalletLibraryVCSDKLogConsumer.kt
@@ -2,7 +2,8 @@ package com.microsoft.walletlibrary.util
 
 import com.microsoft.walletlibrary.did.sdk.util.log.SdkLog
 
-internal class WalletLibraryVCSDKLogConsumer(private val logger: WalletLibraryLogger): SdkLog.Consumer {
+internal object WalletLibraryVCSDKLogConsumer: SdkLog.Consumer {
+    lateinit var logger: WalletLibraryLogger
 
     override fun log(logLevel: SdkLog.Level, message: String, throwable: Throwable?, tag: String) {
         logger.log(mapVcLogLevelToWalletLibraryLogLevel(logLevel), message, throwable, tag)

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/http/httpagent/IResponse.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/http/httpagent/IResponse.kt
@@ -14,11 +14,20 @@ class IResponse(
     val headers: Map<String, String>,
     val body: ByteArray
 ) {
+    companion object {
+        fun getHeaderCaseInsensitive(headerName: String, headers: Map<String, String>): String? {
+            val headerKey = headers.keys.first {
+                it.trim().equals(headerName.trim(), ignoreCase = true)
+            } ?: return null
+            return headers[headerKey]
+        }
+    }
+
     fun toNetworkingException(): NetworkingException {
         var code = status.toString()
         var innerError: String? = null
         var message = ""
-        var correlationId: String? = headers["ms-cv"]
+        var correlationId: String? = IResponse.getHeaderCaseInsensitive("ms-cv", headers)
         var bodyAsString: String? = null
         val retryable: Boolean = headers.containsKey(HttpHeaders.RETRY_AFTER)
         try {

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/http/httpagent/IResponse.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/http/httpagent/IResponse.kt
@@ -63,7 +63,8 @@ class IResponse(
             statusCode = status.toString(),
             innerError = innerError,
             errorBody = bodyAsString,
-            retryable = retryable
+            retryable = retryable,
+            headers = headers
         )
     }
 }


### PR DESCRIPTION
**Problem:**
Log lines are emitted multiple times per call. On Network calls, mscv and request-id are "None". 


**Solution:**
* Switch log consumers from "list" to "set"
* Transform loggers to singletons to have the same object ids
* Abstract out header operations to perform case-insensitive matches
* Add headers to the NetworkException exception
* Add "cause" to presentation errors to preserve callstack errors for better error handling


**Validation:**
Tested against main build


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
3420258