### PR TITLE
Fix breaking bug when no mscv is provided

### DIFF
--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/http/httpagent/IResponse.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/util/http/httpagent/IResponse.kt
@@ -16,7 +16,7 @@ class IResponse(
 ) {
     companion object {
         fun getHeaderCaseInsensitive(headerName: String, headers: Map<String, String>): String? {
-            val headerKey = headers.keys.first {
+            val headerKey = headers.keys.firstOrNull {
                 it.trim().equals(headerName.trim(), ignoreCase = true)
             } ?: return null
             return headers[headerKey]


### PR DESCRIPTION
**Problem:**
when no ms-cv header is returned, an exception is thrown that breaks the flow.


**Solution:**
first**OrNull**


**Validation:**
Please include here how it was verified that the PR works as intended.
end-to-end validation against failing service.

**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:


**Documentation Links**: