### PR TITLE
Replace okhttp3 internal filterList with Kotlin stdlib filter

### DIFF
--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/requirements/VerifiedIdRequirement.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/requirements/VerifiedIdRequirement.kt
@@ -18,7 +18,6 @@ import com.microsoft.walletlibrary.util.VerifiedIdExceptions
 import com.microsoft.walletlibrary.util.VerifiedIdResult
 import com.microsoft.walletlibrary.verifiedid.VerifiedId
 import com.microsoft.walletlibrary.verifiedid.VerifiedIdSerializer
-import okhttp3.internal.filterList
 
 /**
  * Represents information that describes Verified IDs required in order to complete a VerifiedID request.
@@ -52,7 +51,7 @@ open class VerifiedIdRequirement(
     internal var constraint: VerifiedIdConstraint = toVcTypeConstraint()
 
     internal fun toVcTypeConstraint(): VerifiedIdConstraint {
-        if (types.isEmpty() || types.filterList { isNotBlank() }
+        if (types.isEmpty() || types.filter { it.isNotBlank() }
                 .isEmpty()) throw MalformedInputException(
             "There is no Verified ID type in the request.",
             VerifiedIdExceptions.MALFORMED_INPUT_EXCEPTION.value


### PR DESCRIPTION
## Problem

`okhttp3.internal.filterList` is an internal OkHttp API, not part of the public contract. It can silently break on any OkHttp version bump since internal APIs carry no compatibility guarantees.

## Solution

Replaced `okhttp3.internal.filterList` with Kotlin stdlib's `filter` in `VerifiedIdRequirement.kt`. The two are functionally identical — `filterList` in OkHttp is just a wrapper around the same predicate-based filtering.

**Changes:**
- `VerifiedIdRequirement.kt`: removed `import okhttp3.internal.filterList`, replaced `types.filterList { isNotBlank() }` with `types.filter { it.isNotBlank() }`

## Validation

- Existing unit tests for `VerifiedIdRequirement` cover the `toVcTypeConstraint()` path and continue to pass
- Behavior is identical — `filter { it.isNotBlank() }` produces the same result as `filterList { isNotBlank() }`

## Type of change
- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk
- [ ] High – Errors could cause MAJOR regression of many scenarios.
- [ ] Medium – Errors could cause regression of 1 or more scenarios.
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Work Item links

N/A

## Documentation Links

N/A