### PR TITLE
Expose credentialIssuer and credentialEndpoint on VerifiedIdIssuanceRequest

### DIFF
--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/ManifestIssuanceRequest.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/ManifestIssuanceRequest.kt
@@ -45,6 +45,13 @@ internal class ManifestIssuanceRequest(
 
     private val libraryConfiguration: LibraryConfiguration
 ) : VerifiedIdIssuanceRequest {
+
+    override val credentialIssuer: String?
+        get() = request.rawRequest.contract.input.credentialIssuer
+
+    override val credentialEndpoint: String?
+        get() = null // Legacy flow uses credentialIssuer as POST target
+
     // Completes the issuance request and returns a Result with VerifiedId if successful.
     override suspend fun complete(): VerifiedIdResult<VerifiedId> {
         val result = getResult {

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/VerifiedIdIssuanceRequest.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/VerifiedIdIssuanceRequest.kt
@@ -20,6 +20,23 @@ interface VerifiedIdIssuanceRequest : VerifiedIdRequest<VerifiedId> {
     // Attributes describing the Verified ID (eg. name, issuer, logo, background and text colors).
     val verifiedIdStyle: VerifiedIdStyle
 
+    /**
+     * The credential issuer endpoint URL.
+     *
+     * For legacy manifest issuance, this may also be the endpoint where the issuance response
+     * is sent. For OpenID4VCI, prefer [credentialEndpoint] as the credential request POST target.
+     */
+    val credentialIssuer: String?
+        get() = null
+
+    /**
+     * The credential endpoint URL where the credential request/token is POSTed.
+     *
+     * This is available for OpenID4VCI issuance. It may be null for legacy manifest issuance.
+     */
+    val credentialEndpoint: String?
+        get() = null
+
     // Completes the request and returns a VerifiedID if successful.
     override suspend fun complete(): VerifiedIdResult<VerifiedId>
 }

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/VerifiedIdIssuanceRequest.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/VerifiedIdIssuanceRequest.kt
@@ -30,9 +30,9 @@ interface VerifiedIdIssuanceRequest : VerifiedIdRequest<VerifiedId> {
         get() = null
 
     /**
-     * The credential endpoint URL where the credential request/token is POSTed.
+     * The credential endpoint URL where the credential request is POSTed.
      *
-     * This is available for OpenID4VCI issuance. It may be null for legacy manifest issuance.
+     * This is available for OpenID4VCI issuance. It will be null for legacy manifest issuance.
      */
     val credentialEndpoint: String?
         get() = null

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/handlers/OpenIdRequestProcessor.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/handlers/OpenIdRequestProcessor.kt
@@ -99,6 +99,7 @@ class OpenIdRequestProcessor internal constructor(private val libraryConfigurati
             presentationRequestContent.requestState,
             presentationRequestContent.issuanceCallbackUrl
         )
+
         val issuanceRequestContent = rawManifest.mapToIssuanceRequestContent()
         val identifier = libraryConfiguration.identifierFactory.getIdentifier().id
         val nonce = NonceProcessor.getNonce(identifier)

--- a/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/openid4vci/OpenId4VciIssuanceRequest.kt
+++ b/walletlibrary/src/main/java/com/microsoft/walletlibrary/requests/openid4vci/OpenId4VciIssuanceRequest.kt
@@ -62,6 +62,12 @@ internal class OpenId4VciIssuanceRequest(
 ) : VerifiedIdIssuanceRequest {
     private val requestFormatter = OpenId4VciIssuanceRequestFormatter(libraryConfiguration)
 
+    override val credentialIssuer: String?
+        get() = credentialMetadata.credentialIssuer
+
+    override val credentialEndpoint: String?
+        get() = credentialMetadata.credentialEndpoint
+
     override suspend fun complete(): VerifiedIdResult<VerifiedId> {
         val result = getResult {
             val response = formatAndSendIssuanceRequest()


### PR DESCRIPTION
Description:

Adds credentialIssuer and credentialEndpoint properties to the VerifiedIdIssuanceRequest interface, allowing consuming apps to access the issuance endpoint URLs for validation purposes.

Changes:

- VerifiedIdIssuanceRequest: Added credentialIssuer: String? and credentialEndpoint: String? to the public interface
- ManifestIssuanceRequest: Implements credentialIssuer from contract.input.credentialIssuer; credentialEndpoint returns null (not applicable for manifest-based flow)
- OpenId4VciIssuanceRequest: Implements both from credentialMetadata
- OpenIdRequestProcessor: Minor cleanup