### PR TITLE
Add build-time secret injection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ val client = VerifiedIdClientBuilder(context)
     .build()
 ```
 
+## Secret injection
+Build-time secrets should not be hardcoded in the repository. The library now supports a `wallet_library_api_key` property that can be supplied through a local environment variable (`WALLET_LIBRARY_API_KEY`) or through Gradle properties.
+
+For CI or local automation, use the helper script at `scripts/resolve-wallet-library-secret.sh`. It reads from `WALLET_LIBRARY_API_KEY` first and can also resolve a secret from Azure Key Vault when the following environment variables are provided:
+- `AZURE_KEY_VAULT_NAME`
+- `AZURE_KEY_VAULT_SECRET_NAME`
+
+The helper prints the resolved value and, when `GITHUB_ENV` is set, exports it as `WALLET_LIBRARY_API_KEY` for the next workflow step.
+
 ## Documentation
 
 * [External Architecture](https://github.com/microsoft/entra-verifiedid-wallet-library-ios/blob/dev/Docs/LibraryArchitecture.md)

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,6 +29,9 @@ compile_sdk_version=34
 min_sdk_version=27
 target_sdk_version=34
 
+# Optional build-time secret injected by CI or a local shell.
+wallet_library_api_key=
+
 # Versions of package dependencies (alphabetical)
 androidx_appcompat_version=1.4.2
 androidx_fragment_version=1.3.2

--- a/scripts/resolve-wallet-library-secret.sh
+++ b/scripts/resolve-wallet-library-secret.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -n "${WALLET_LIBRARY_API_KEY:-}" ]; then
+  secret_value="${WALLET_LIBRARY_API_KEY}"
+else
+  if [ -n "${AZURE_KEY_VAULT_NAME:-}" ] && [ -n "${AZURE_KEY_VAULT_SECRET_NAME:-}" ]; then
+    if command -v az >/dev/null 2>&1; then
+      secret_value="$(az keyvault secret show --name "$AZURE_KEY_VAULT_SECRET_NAME" --vault-name "$AZURE_KEY_VAULT_NAME" --query value -o tsv)"
+    else
+      echo "Azure CLI is required when Azure Key Vault variables are provided" >&2
+      exit 1
+    fi
+  else
+    secret_value=""
+  fi
+fi
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "WALLET_LIBRARY_API_KEY=${secret_value}" >> "$GITHUB_ENV"
+fi
+
+echo "$secret_value"

--- a/walletlibrary/build.gradle
+++ b/walletlibrary/build.gradle
@@ -29,7 +29,9 @@ android {
         targetSdkVersion target_sdk_version as Integer
         versionCode 1
         versionName _version
+        def walletLibraryApiKey = project.findProperty('wallet_library_api_key') ?: System.getenv('WALLET_LIBRARY_API_KEY') ?: ''
         buildConfigField 'String', 'WalletLibraryVersion', "\"$_version\""
+        buildConfigField 'String', 'WalletLibraryApiKey', "\"${walletLibraryApiKey}\""
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         


### PR DESCRIPTION
## Summary
- add build-time support for a wallet-library API key via Gradle properties or environment variables
- document how to resolve the value from Azure Key Vault in CI or local automation
- add a helper script for CI/local secret resolution

## Validation
- attempted to run `./gradlew :walletlibrary:testDebugUnitTest`, but the container does not have an Android SDK configured, so Gradle stopped before execution.